### PR TITLE
Improve mobile layout support

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,7 @@
-    html,body,#map{height:100%;margin:0}
+    html,body,#map{height:100vh;margin:0}
+    @supports(height:100dvh){
+      html,body,#map{height:100dvh}
+    }
     html,body{
       font:14px/1.35 system-ui,-apple-system,"Segoe UI",Roboto,Arial,
             "Apple Color Emoji","Segoe UI Emoji","Noto Color Emoji";

--- a/js/app.js
+++ b/js/app.js
@@ -660,7 +660,10 @@ function highlightRouteFor(p, coord){
     bindControlHandlers(controlsRoot);
   }
   function debounce(fn, ms=150){ let t=0; return (...a)=>{ clearTimeout(t); t=setTimeout(()=>fn(...a), ms); }; }
-  window.addEventListener('resize', debounce(placeControls, 150));
+  window.addEventListener('resize', debounce(() => {
+    placeControls();
+    map.resize();
+  }, 150));
 
   function setRoutesVisibility(state){
     const vis = state ? 'visible' : 'none';


### PR DESCRIPTION
## Summary
- use dynamic viewport units to size the map on mobile devices
- resize map on window resize to keep controls in sync

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5da45bbd48331962d05c11f8665bf