### PR TITLE
Add coffee-themed favicon

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f3d5b5" />
+      <stop offset="100%" stop-color="#c38154" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#bg)" />
+  <g fill="#fff">
+    <path d="M18 25h20a6 6 0 0 1 6 6v7a8 8 0 0 1-8 8H24a8 8 0 0 1-8-8V25z" opacity="0.9" />
+    <path d="M44 31h4a4 4 0 0 1 0 8h-5.5a8.5 8.5 0 0 0 1.5-5v-3z" opacity="0.9" />
+    <path d="M22 46h18" stroke="#fff" stroke-linecap="round" stroke-width="4" opacity="0.75" />
+    <path d="M27 18c0 3-3 3-3 6s3 3 3 6" fill="none" stroke="#fff" stroke-width="3" stroke-linecap="round" />
+    <path d="M34 18c0 3-3 3-3 6s3 3 3 6" fill="none" stroke="#fff" stroke-width="3" stroke-linecap="round" />
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
   <title>Coffee Log — Map</title>
+  <link rel="icon" type="image/svg+xml" href="favicon.svg" />
 
   <!-- Mapbox + PapaParse -->
   <link href="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.css" rel="stylesheet">


### PR DESCRIPTION
## Summary
- add a coffee-inspired SVG favicon to the site
- reference the favicon from the HTML head so browsers display it

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c899c8004883319c667d171fadfa3a