### PR TITLE
Improve mobile layout responsiveness

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -671,6 +671,32 @@ input[type="checkbox"]{
   }
 }
 
+@media (max-width:560px){
+  .app-shell{
+    width:calc(100% - 24px);
+    margin:20px auto;
+    gap:20px;
+  }
+
+  .brand-card{
+    flex-direction:column;
+    align-items:flex-start;
+    text-align:left;
+  }
+
+  .map-shell{
+    gap:16px;
+  }
+
+  .map-header .map-title{
+    font-size:24px;
+  }
+
+  .map-header .map-subtitle{
+    font-size:14px;
+  }
+}
+
 @media (max-width:480px){
   .map-frame{
     min-height:300px;

--- a/js/app.js
+++ b/js/app.js
@@ -769,7 +769,19 @@ function highlightRouteFor(p, coord){
       fitToData({ type:'FeatureCollection', features: filtered });
     }
   }
-  function isMobile(){ return window.matchMedia('(max-width: 680px)').matches; }
+  function isMobile(){
+    const desktop = document.getElementById('desktopControls');
+    if (desktop){
+      const desktopDisplay = window.getComputedStyle(desktop).display;
+      if (desktopDisplay && desktopDisplay !== 'none') return false;
+    }
+    const details = document.getElementById('filtersDetails');
+    if (details){
+      const detailsDisplay = window.getComputedStyle(details).display;
+      if (detailsDisplay && detailsDisplay !== 'none') return true;
+    }
+    return window.matchMedia('(max-width: 720px)').matches;
+  }
   function placeControls(){
     const desktop = document.getElementById('desktopControls');
     const mobile = document.getElementById('mobileControls');


### PR DESCRIPTION
## Summary
- ensure filter controls move to the mobile drawer whenever the layout hides the desktop panel
- tighten small-screen spacing for the app shell, brand block, and map header so the layout fits mobile viewports better

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c90e1555188331921a3ca92e03da4c