### PR TITLE
Fix map panel stretching on desktop

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -107,6 +107,7 @@ body[data-theme="dark"]{
 .map-panel{
   grid-area:map;
   display:flex;
+  align-items:flex-start;
 }
 
 .brand-card{


### PR DESCRIPTION
## Summary
- prevent the map panel from stretching to match the sidebar height on wide layouts

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c91eab2f148331b8511c0a644d5706