### PR TITLE
Fix map container fill sizing

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -504,8 +504,11 @@ input[type="checkbox"]{
 }
 
 #map{
-  width:100%;
-  height:100%;
+  position:absolute;
+  top:0;
+  right:0;
+  bottom:0;
+  left:0;
 }
 
 .mapboxgl-popup-content{


### PR DESCRIPTION
## Summary
- ensure the map canvas stretches to fill its frame by absolutely positioning the map container
- preserve the existing map frame layout while keeping the map visible across breakpoints

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c9290841788331a36cf6dbbd18f99f