### PR TITLE
Refine layout to fill viewport

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -17,6 +17,11 @@ body{
   -webkit-font-smoothing:antialiased;
   -moz-osx-font-smoothing:grayscale;
   -webkit-tap-highlight-color:transparent;
+  min-height:100vh;
+  display:flex;
+  justify-content:center;
+  align-items:stretch;
+  padding:32px 24px;
 }
 
 @supports(height:100dvh){
@@ -88,12 +93,13 @@ body[data-theme="dark"]{
 }
 
 .app-shell{
-  width:min(1240px,100% - 48px);
-  margin:32px auto;
+  flex:1 1 0;
+  max-width:1200px;
+  width:100%;
   display:grid;
-  grid-template-columns:minmax(260px,360px) minmax(0,1fr);
+  grid-template-columns:minmax(240px,300px) minmax(0,1fr);
   grid-template-areas:"side map";
-  gap:32px;
+  gap:28px;
   align-items:stretch;
 }
 
@@ -101,20 +107,21 @@ body[data-theme="dark"]{
   grid-area:side;
   display:flex;
   flex-direction:column;
-  gap:24px;
+  gap:20px;
 }
 
 .map-panel{
   grid-area:map;
   display:flex;
-  align-items:flex-start;
+  flex-direction:column;
+  min-height:0;
 }
 
 .brand-card{
   display:flex;
-  gap:16px;
-  align-items:center;
-  padding:20px 24px;
+  flex-direction:column;
+  gap:20px;
+  padding:28px;
 }
 
 .brand-icon{
@@ -133,7 +140,7 @@ body[data-theme="dark"]{
 .brand-copy{
   display:flex;
   flex-direction:column;
-  gap:4px;
+  gap:6px;
 }
 
 .brand-eyebrow{
@@ -146,25 +153,41 @@ body[data-theme="dark"]{
   color:var(--accent);
 }
 
-.brand-copy p{
-  color:var(--muted);
-  font-size:15px;
+.brand-header{
+  display:flex;
+  align-items:center;
+  gap:18px;
 }
 
-.collection-card{
-  padding:26px 24px;
-}
-
-.collection-card .collection-title{
-  margin:8px 0 16px;
-  font-size:28px;
+.brand-title{
+  margin:0;
+  font-size:30px;
   font-weight:700;
   color:var(--text);
+  line-height:1.15;
 }
 
-.collection-description{
+.brand-lead{
   color:var(--muted);
   font-size:15px;
+}
+
+.brand-tags{
+  display:flex;
+  flex-wrap:wrap;
+  gap:10px;
+}
+
+.brand-tag{
+  border-color:rgba(194,109,67,0.35);
+  background:var(--accent-soft);
+  color:var(--accent);
+  font-family:var(--font-ui);
+  font-weight:600;
+}
+
+body[data-theme="dark"] .brand-tag{
+  border-color:rgba(245,158,11,0.35);
 }
 
 .eyebrow{
@@ -479,6 +502,8 @@ input[type="checkbox"]{
   flex-direction:column;
   gap:18px;
   padding:28px;
+  flex:1 1 auto;
+  min-height:0;
 }
 
 .map-header .map-title{
@@ -495,8 +520,9 @@ input[type="checkbox"]{
 
 .map-frame{
   position:relative;
-  flex:1;
-  min-height:520px;
+  flex:1 1 auto;
+  min-height:460px;
+  height:100%;
   border-radius:22px;
   overflow:hidden;
   box-shadow:var(--map-shadow);
@@ -605,8 +631,11 @@ input[type="checkbox"]{
 }
 
 @media (max-width:1200px){
+  body{
+    padding:32px 20px;
+  }
+
   .app-shell{
-    width:min(1120px,100% - 32px);
     gap:24px;
   }
 
@@ -616,28 +645,26 @@ input[type="checkbox"]{
 }
 
 @media (max-width:960px){
+  body{
+    padding:28px 18px;
+  }
+
   .app-shell{
     grid-template-columns:1fr;
     grid-template-areas:'map' 'side';
   }
 
-  .map-shell{
-    min-height:520px;
-  }
-
   .map-frame{
-    min-height:420px;
+    min-height:400px;
   }
 }
 
 @media (max-width:720px){
   body{
-    padding-bottom:32px;
+    padding:24px 16px 32px;
   }
 
   .app-shell{
-    width:calc(100% - 32px);
-    margin:24px auto;
     gap:24px;
   }
 
@@ -646,20 +673,24 @@ input[type="checkbox"]{
     padding:20px;
   }
 
+  .brand-card{
+    padding:22px;
+  }
+
+  .brand-title{
+    font-size:26px;
+  }
+
   .map-shell{
     padding:20px;
   }
 
   .map-frame{
-    min-height:360px;
+    min-height:340px;
   }
 
   .panel-card{
     padding:22px 20px;
-  }
-
-  .collection-card .collection-title{
-    font-size:24px;
   }
 
   .desktop-controls{
@@ -676,16 +707,41 @@ input[type="checkbox"]{
 }
 
 @media (max-width:560px){
+  body{
+    padding:20px 12px 28px;
+  }
+
   .app-shell{
-    width:calc(100% - 24px);
-    margin:20px auto;
     gap:20px;
   }
 
   .brand-card{
-    flex-direction:column;
+    padding:20px;
+  }
+
+  .brand-header{
+    flex-direction:row;
     align-items:flex-start;
-    text-align:left;
+    gap:14px;
+  }
+
+  .brand-icon{
+    width:48px;
+    height:48px;
+    font-size:22px;
+  }
+
+  .brand-title{
+    font-size:24px;
+  }
+
+  .brand-tags{
+    gap:8px;
+  }
+
+  .brand-tag{
+    padding:6px 10px;
+    font-size:13px;
   }
 
   .map-shell{

--- a/index.html
+++ b/index.html
@@ -20,24 +20,26 @@
   <div class="app-shell">
     <aside class="side-panel">
       <div class="brand-card glass-card">
-        <div class="brand-icon">☕</div>
-        <div class="brand-copy">
-          <span class="brand-eyebrow">Coffee log</span>
-          <p>Личная карта впечатлений от кофе, собранных по всему миру.</p>
+        <div class="brand-header">
+          <div class="brand-icon">☕</div>
+          <div class="brand-copy">
+            <span class="brand-eyebrow">Coffee log</span>
+            <h1 class="brand-title" id="collectionTitle">My coffee experience</h1>
+          </div>
         </div>
-      </div>
-
-      <div class="collection-card glass-card">
-        <span class="eyebrow">Коллекция</span>
-        <h1 class="collection-title" id="collectionTitle">My coffee experience</h1>
-        <p class="collection-description">Живая карта с точками происхождения зерна, обжарщиков и заведений, где был выпит каждый напиток.</p>
+        <p class="brand-lead">Живая карта впечатлений от зерна и чашек, собранных во время путешествий и дегустаций.</p>
+        <div class="brand-tags">
+          <span class="chip brand-tag">⛺ Маршруты</span>
+          <span class="chip brand-tag">🔥 Обжарщики</span>
+          <span class="chip brand-tag">🏙️ Кафе</span>
+        </div>
       </div>
 
       <div class="panel-card glass-card" id="badge">
         <div class="panel-intro">
           <span class="eyebrow">Интерактивные фильтры</span>
-          <h2>Настройте отображение</h2>
-          <p>Используйте переключатели и цветные фильтры, чтобы подсветить маршруты, закрасить страны, увидеть только свои записи и отобрать зерно по обработке.</p>
+          <h2>Настройте карту под себя</h2>
+          <p>Выделяйте маршруты, подсвечивайте страны, показывайте свои заметки или выбирайте зерно по типу обработки.</p>
         </div>
         <div class="desktop-controls" id="desktopControls"></div>
         <details id="filtersDetails">


### PR DESCRIPTION
## Summary
- merge the intro and collection details into a single compact hero card with quick tags
- make the shell and map panels stretch to the viewport height while shrinking the side column width
- retune responsive spacing and copy to remove the blank bottom edge on all breakpoints

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c96deac1088331a2eafea6aa9cbd21