### PR TITLE
Adjust layout scaling for large viewports

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -94,10 +94,10 @@ body[data-theme="dark"]{
 
 .app-shell{
   flex:1 1 0;
-  max-width:1200px;
+  max-width:min(1600px,95vw);
   width:100%;
   display:grid;
-  grid-template-columns:minmax(240px,300px) minmax(0,1fr);
+  grid-template-columns:minmax(260px,320px) minmax(0,1fr);
   grid-template-areas:"side map";
   gap:28px;
   align-items:stretch;
@@ -641,6 +641,15 @@ input[type="checkbox"]{
 
   .map-shell{
     padding:24px;
+  }
+}
+
+@media (min-width:1200px){
+  body{
+    padding-top:40px;
+    padding-bottom:40px;
+    padding-left:clamp(24px,4vw,56px);
+    padding-right:clamp(24px,4vw,56px);
   }
 }
 


### PR DESCRIPTION
## Summary
- expand the app shell width cap to allow the layout to stretch on large displays
- refine grid columns so the sidebar keeps a consistent footprint while the map expands
- tune large screen body padding to keep outer gutters balanced without constraining the content

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cbf890f5e48331b201c527325c01d2