### PR TITLE
Adjust mobile map layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -680,6 +680,13 @@ input[type="checkbox"]{
 
   .map-shell{
     padding:20px;
+    flex:0 0 auto;
+  }
+
+  .map-frame{
+    flex:0 0 auto;
+    min-height:clamp(260px, 55vh, 480px);
+    height:clamp(280px, 60vh, 520px);
   }
 
   .panel-card{


### PR DESCRIPTION
## Summary
- prevent the map card from stretching to fill the full viewport on narrow screens
- reduce the map container height on phones so the rest of the content stays visible

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd26bd72188331a3156699a96d5205