### PR TITLE
Fix mobile layout stacking on small screens

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -647,6 +647,7 @@ input[type="checkbox"]{
 @media (max-width:960px){
   body{
     padding:28px 18px;
+    display:block;
   }
 
   .app-shell{


### PR DESCRIPTION
## Summary
- switch the page body to block layout on viewports below 960px so the grid can grow vertically and cards no longer overlap on mobile

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ceaef772f48331ba892439ac68b12d