### PR TITLE
feat: hide map instructions behind info toggle

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -133,10 +133,49 @@ body[data-theme="dark"]{
   pointer-events:auto;
 }
 
+.map-title-row{
+  display:flex;
+  align-items:flex-start;
+  justify-content:space-between;
+  gap:12px;
+}
+
 .map-banner .map-title{
   font-size:28px;
   font-weight:700;
   color:var(--text);
+}
+
+.map-info-toggle{
+  border:0;
+  padding:6px;
+  border-radius:50%;
+  background:var(--accent-soft);
+  color:var(--accent);
+  font-size:18px;
+  line-height:1;
+  cursor:pointer;
+  transition:background-color 0.2s ease,color 0.2s ease;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  flex-shrink:0;
+}
+
+.map-info-toggle:hover,
+.map-info-toggle:focus-visible{
+  background:var(--accent);
+  color:#fff;
+  outline:none;
+}
+
+.map-info-toggle:focus:not(:focus-visible){
+  outline:none;
+}
+
+.map-info-toggle[aria-expanded="true"]{
+  background:var(--accent);
+  color:#fff;
 }
 
 .map-banner .map-subtitle{
@@ -144,6 +183,18 @@ body[data-theme="dark"]{
   color:var(--muted);
   font-size:15px;
   line-height:1.6;
+}
+
+.sr-only{
+  position:absolute;
+  width:1px;
+  height:1px;
+  padding:0;
+  margin:-1px;
+  overflow:hidden;
+  clip:rect(0,0,0,0);
+  white-space:nowrap;
+  border:0;
 }
 
 .map-overlays{

--- a/index.html
+++ b/index.html
@@ -22,9 +22,14 @@
 
     <div class="map-ui">
       <header class="map-banner">
-        <span class="eyebrow">Интерактивная карта</span>
-        <h1 class="map-title" id="collectionTitle">my coffee experience</h1>
-        <p class="map-subtitle">Передвигайте карту и кликайте на маркеры, чтобы увидеть путь зерна от фермы до чашки.</p>
+        <div class="map-title-row">
+          <h1 class="map-title" id="collectionTitle">my coffee experience</h1>
+          <button class="map-info-toggle" type="button" aria-expanded="false" aria-controls="mapInfoText" data-map-info-toggle>
+            <span aria-hidden="true">ℹ️</span>
+            <span class="sr-only">Показать пояснения</span>
+          </button>
+        </div>
+        <p class="map-subtitle" id="mapInfoText" data-map-info-panel hidden>Передвигайте карту и кликайте на маркеры, чтобы увидеть путь зерна от фермы до чашки.</p>
       </header>
 
       <div class="map-overlays">

--- a/js/app.js
+++ b/js/app.js
@@ -10,6 +10,46 @@ const theme = (new URLSearchParams(location.search).get('style') || 'light').toL
 document.body.dataset.theme = theme;
 const flagMode = (new URLSearchParams(location.search).get('flag') || 'img').toLowerCase();
 
+function setupInfoToggle() {
+  const toggle = document.querySelector('[data-map-info-toggle]');
+  const panel = document.querySelector('[data-map-info-panel]');
+  if (!toggle || !panel) return;
+
+  const closePanel = () => {
+    panel.hidden = true;
+    toggle.setAttribute('aria-expanded', 'false');
+  };
+
+  const openPanel = () => {
+    panel.hidden = false;
+    toggle.setAttribute('aria-expanded', 'true');
+  };
+
+  toggle.addEventListener('click', () => {
+    const expanded = toggle.getAttribute('aria-expanded') === 'true';
+    if (expanded) {
+      closePanel();
+    } else {
+      openPanel();
+    }
+  });
+
+  document.addEventListener('click', (event) => {
+    if (panel.hidden) return;
+    if (toggle.contains(event.target) || panel.contains(event.target)) return;
+    closePanel();
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key !== 'Escape' || panel.hidden) return;
+    event.preventDefault();
+    closePanel();
+    toggle.focus();
+  });
+}
+
+setupInfoToggle();
+
 const mapController = createMapController({ accessToken: MAPBOX_TOKEN, theme, flagMode });
 const overlayMedia = window.matchMedia('(max-width: 720px)');
 


### PR DESCRIPTION
## Summary
- remove the "Интерактивная карта" eyebrow from the map banner
- add an info button that toggles the explanatory text on demand
- style and script the new toggle to work with keyboard and pointer interactions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d525604fbc8331840198642f50f469