### PR TITLE
feat: show OCR recognition summary and field states

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,23 @@ Coffeemap-mapbox-googleshhets
 - `index.html` – main entry point
 - `css/style.css` – extracted styles
 - `js/app.js` – extracted scripts
+- `js/photo-import.js` – модуль распознавания данных с фото и подготовки отправки в Google форму
+- `js/config.js` – параметры подключения к Google форме для автозаполнения
+
+## Фото-импорт в Google Docs/Sheets
+
+1. Откройте страницу и загрузите фото этикетки или карточки кофе в блоке «Загрузка по фото».
+2. После распознавания при необходимости отредактируйте предложенные поля.
+3. Нажмите «Скопировать данные» или «Автозаполнить Google форму».
+
+### Настройка Google формы
+
+1. Создайте Google Form, связанную с нужной таблицей Google Sheets/Docs.
+2. В режиме предзаполнения формы скопируйте значения параметров `entry.xxxxx` для требуемых вопросов.
+3. Отредактируйте файл `js/config.js`:
+   - Установите `enabled: true`.
+   - Укажите `prefillBaseUrl` (ссылка вида `https://docs.google.com/forms/d/e/.../viewform`).
+   - Заполните `entryMap`, сопоставив поля формы с ключами `coffeeName`, `roasterName`, `origin`, `process`, `brewMethod`, `notes`, `rawText`.
+4. При необходимости добавьте дополнительные параметры запроса в `extraParams` (по умолчанию `usp=pp_url`).
+
+После настройки кнопка автозаполнения откроет форму Google с уже вставленными распознанными данными.

--- a/css/style.css
+++ b/css/style.css
@@ -198,6 +198,281 @@ body[data-theme="dark"] .brand-tag{
   font-weight:600;
 }
 
+.photo-card{
+  display:flex;
+  flex-direction:column;
+  gap:18px;
+}
+
+.photo-card__header{
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+}
+
+.photo-card__header h2{
+  font-size:24px;
+  font-weight:700;
+  color:var(--text);
+}
+
+.photo-card__lead{
+  margin:0;
+  font-size:15px;
+  color:var(--muted);
+}
+
+.photo-upload{
+  position:relative;
+  border:1.5px dashed var(--pill-border);
+  border-radius:18px;
+  padding:18px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  text-align:center;
+  gap:10px;
+  color:var(--muted);
+  cursor:pointer;
+  transition:border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
+}
+
+.photo-upload__text{
+  font-family:var(--font-ui);
+  font-weight:600;
+  font-size:14px;
+}
+
+.photo-upload:hover{
+  border-color:var(--accent);
+  color:var(--accent);
+  background:var(--accent-soft);
+}
+
+.photo-upload input{
+  position:absolute;
+  inset:0;
+  width:100%;
+  height:100%;
+  opacity:0;
+  cursor:pointer;
+}
+
+.photo-status{
+  font-family:var(--font-ui);
+  font-size:14px;
+  color:var(--muted);
+}
+
+.photo-status[data-tone="success"]{color:#15803d;}
+.photo-status[data-tone="error"]{color:#dc2626;}
+.photo-status[data-tone="warning"]{color:#ca8a04;}
+.photo-status[data-tone="progress"]{color:var(--accent);}
+
+.photo-ocr-text{
+  width:100%;
+  resize:vertical;
+  min-height:120px;
+  border-radius:16px;
+  border:1px solid var(--pill-border);
+  padding:12px 14px;
+  font-family:'Golos Text',var(--font-base);
+  font-size:14px;
+  line-height:1.5;
+  background:var(--surface-strong);
+  color:var(--text);
+}
+
+.photo-summary{
+  border:1px solid var(--pill-border);
+  border-radius:16px;
+  padding:14px 16px;
+  background:var(--surface-strong);
+  display:flex;
+  flex-direction:column;
+  gap:10px;
+  font-family:var(--font-ui);
+  font-size:13px;
+  color:var(--muted);
+}
+
+.photo-summary__placeholder{
+  margin:0;
+}
+
+.photo-summary__sections{
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+}
+
+.photo-summary__section{
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+}
+
+.photo-summary__label{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  font-weight:600;
+  color:var(--text);
+}
+
+.photo-summary__label[data-tone="auto"]{color:#15803d;}
+.photo-summary__label[data-tone="manual"]{color:#1d4ed8;}
+.photo-summary__label[data-tone="empty"]{color:#ca8a04;}
+
+.photo-summary__list{
+  margin:0;
+  padding-left:18px;
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+}
+
+.photo-summary__list li{
+  list-style:disc;
+}
+
+.photo-form{
+  display:grid;
+  gap:12px;
+}
+
+.photo-field label{
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+  font-size:13px;
+  color:var(--muted);
+  font-weight:600;
+}
+
+.photo-field__status{
+  font-size:12px;
+  font-weight:500;
+  color:var(--muted);
+}
+
+.photo-field[data-state="auto"] .photo-field__status{
+  color:#15803d;
+}
+
+.photo-field[data-state="manual"] .photo-field__status{
+  color:#1d4ed8;
+}
+
+.photo-field[data-state="empty"] .photo-field__status{
+  color:#ca8a04;
+}
+
+.photo-field[data-state="auto"] input,
+.photo-field[data-state="auto"] textarea{
+  border-color:rgba(21,128,61,0.5);
+  box-shadow:0 0 0 2px rgba(21,128,61,0.15);
+}
+
+.photo-field[data-state="manual"] input,
+.photo-field[data-state="manual"] textarea{
+  border-color:rgba(29,78,216,0.5);
+  box-shadow:0 0 0 2px rgba(29,78,216,0.15);
+}
+
+.photo-field[data-state="empty"] input,
+.photo-field[data-state="empty"] textarea{
+  border-color:var(--pill-border);
+  box-shadow:none;
+}
+
+.photo-field input,
+.photo-field textarea{
+  border-radius:14px;
+  border:1px solid var(--pill-border);
+  padding:10px 12px;
+  font-family:var(--font-ui);
+  font-size:14px;
+  background:var(--surface-strong);
+  color:var(--text);
+  transition:border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.photo-field input:focus,
+.photo-field textarea:focus{
+  outline:none;
+  border-color:var(--accent);
+  box-shadow:0 0 0 3px rgba(194,109,67,0.25);
+}
+
+.photo-actions{
+  display:flex;
+  flex-wrap:wrap;
+  gap:12px;
+}
+
+.photo-btn{
+  flex:1 1 160px;
+  border-radius:12px;
+  border:1px solid var(--accent);
+  background:transparent;
+  color:var(--accent);
+  font-family:var(--font-ui);
+  font-weight:600;
+  font-size:14px;
+  padding:10px 16px;
+  cursor:pointer;
+  transition:background 0.2s ease, color 0.2s ease;
+}
+
+.photo-btn.primary{
+  background:var(--accent);
+  color:#fff;
+}
+
+.photo-btn:disabled{
+  opacity:0.5;
+  cursor:not-allowed;
+}
+
+.photo-btn:not(:disabled):hover{
+  background:var(--accent);
+  color:#fff;
+}
+
+.photo-btn.primary:not(:disabled):hover{
+  filter:brightness(0.95);
+}
+
+.photo-docs-hint{
+  margin:0;
+  font-size:13px;
+  color:var(--muted);
+}
+
+.photo-hint{
+  margin:0;
+  font-size:13px;
+  color:var(--muted);
+}
+
+body[data-theme="dark"] .photo-upload{
+  border-color:rgba(148,163,184,0.35);
+}
+
+body[data-theme="dark"] .photo-field input,
+body[data-theme="dark"] .photo-field textarea,
+body[data-theme="dark"] .photo-ocr-text{
+  background:rgba(17,24,39,0.92);
+  border-color:rgba(148,163,184,0.25);
+  color:var(--text);
+}
+
+body[data-theme="dark"] .photo-summary{
+  background:rgba(17,24,39,0.92);
+  border-color:rgba(148,163,184,0.25);
+}
+
 .panel-card{
   display:flex;
   flex-direction:column;

--- a/index.html
+++ b/index.html
@@ -39,6 +39,71 @@
         </div>
         <div class="achievements" id="achievements"></div>
       </section>
+
+      <section class="photo-card glass-card" id="photoUploadCard">
+        <div class="photo-card__header">
+          <span class="eyebrow">Загрузка по фото</span>
+          <h2>Распознайте данные автоматически</h2>
+        </div>
+        <p class="photo-card__lead">Добавьте фото с описанием кофе, чтобы распознать текст и подготовить запись для Google Docs.</p>
+        <label class="photo-upload" for="photoUploadInput">
+          <input type="file" id="photoUploadInput" accept="image/*" />
+          <span class="photo-upload__text">Выберите файл или перетащите сюда</span>
+        </label>
+        <div class="photo-status" id="photoOcrStatus"></div>
+        <textarea class="photo-ocr-text" id="photoOcrText" rows="6" placeholder="Распознанный текст появится здесь" readonly></textarea>
+        <div class="photo-summary" id="photoOcrSummary"></div>
+        <p class="photo-hint" id="photoProcessHint"></p>
+        <form class="photo-form" id="photoDetailsForm" autocomplete="off">
+          <div class="photo-field" data-field="coffeeName">
+            <label>
+              <span>Название кофе</span>
+              <input type="text" data-field="coffeeName" placeholder="Например, Ethiopia Chelbesa" />
+              <span class="photo-field__status" data-role="status"></span>
+            </label>
+          </div>
+          <div class="photo-field" data-field="roasterName">
+            <label>
+              <span>Ростер</span>
+              <input type="text" data-field="roasterName" placeholder="Ростер или обжарщик" />
+              <span class="photo-field__status" data-role="status"></span>
+            </label>
+          </div>
+          <div class="photo-field" data-field="origin">
+            <label>
+              <span>Происхождение</span>
+              <input type="text" data-field="origin" placeholder="Страна или регион" />
+              <span class="photo-field__status" data-role="status"></span>
+            </label>
+          </div>
+          <div class="photo-field" data-field="process">
+            <label>
+              <span>Обработка</span>
+              <input type="text" data-field="process" placeholder="Natural, Washed, Honey…" />
+              <span class="photo-field__status" data-role="status"></span>
+            </label>
+          </div>
+          <div class="photo-field" data-field="brewMethod">
+            <label>
+              <span>Метод заваривания</span>
+              <input type="text" data-field="brewMethod" placeholder="V60, Эспрессо и т.д." />
+              <span class="photo-field__status" data-role="status"></span>
+            </label>
+          </div>
+          <div class="photo-field" data-field="notes">
+            <label>
+              <span>Заметки</span>
+              <textarea rows="3" data-field="notes" placeholder="Вкус, оценка, дополнительные детали"></textarea>
+              <span class="photo-field__status" data-role="status"></span>
+            </label>
+          </div>
+        </form>
+        <div class="photo-actions">
+          <button type="button" class="photo-btn" id="photoCopyData" disabled>Скопировать данные</button>
+          <button type="button" class="photo-btn primary" id="photoSendToDocs" disabled>Автозаполнить Google форму</button>
+        </div>
+        <p class="photo-docs-hint" id="photoDocsHint"></p>
+      </section>
     </aside>
 
     <main class="map-panel">

--- a/js/app.js
+++ b/js/app.js
@@ -2,6 +2,8 @@ import { debounce } from './utils.js';
 import { buildCityPoints, buildRouteFeatures, getVisitedCountriesIso2, loadData } from './data-loader.js';
 import { PROCESS_FILTER_VALUES, createUIController, renderAchievements } from './ui-controls.js';
 import { createMapController } from './map-init.js';
+import { initPhotoImport } from './photo-import.js';
+import { GOOGLE_FORM_CONFIG } from './config.js';
 
 const MAPBOX_TOKEN = 'pk.eyJ1IjoibWF4MTQwNTE5OTMtY29mZmVlIiwiYSI6ImNtZTVic3c3dTBxZDMya3F6MzV0ejY1YjcifQ._YoZjruPVrVHtusEf8OkZw';
 const CSV_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vSbms6-9Pie6VdyXzbjiMwWeIF-mxMvMiyFHaRI1DJE0nPNkSG99lewaeeU8YIuj7Y8vxzJGOD2md1v/pub?gid=1055803810&single=true&output=csv';
@@ -11,6 +13,7 @@ document.body.dataset.theme = theme;
 const flagMode = (new URLSearchParams(location.search).get('flag') || 'img').toLowerCase();
 
 const mapController = createMapController({ accessToken: MAPBOX_TOKEN, theme, flagMode });
+initPhotoImport({ googleFormConfig: GOOGLE_FORM_CONFIG });
 
 const filterState = { mine: false, process: 'all' };
 let allPointFeatures = [];

--- a/js/config.js
+++ b/js/config.js
@@ -1,0 +1,28 @@
+export const GOOGLE_FORM_CONFIG = {
+  enabled: false,
+  /**
+   * URL of the Google Form "viewform" page with prefill support.
+   * Example: "https://docs.google.com/forms/d/e/.../viewform"
+   */
+  prefillBaseUrl: '',
+  /**
+   * Map internal field keys to Google Form entry IDs.
+   * Fill the entry IDs from the Google Form prefilled URL parameters.
+   */
+  entryMap: {
+    coffeeName: '',
+    roasterName: '',
+    origin: '',
+    process: '',
+    brewMethod: '',
+    notes: '',
+    rawText: '',
+  },
+  /**
+   * Additional static parameters appended to the prefill URL.
+   * Example: { usp: 'pp_url' }
+   */
+  extraParams: {
+    usp: 'pp_url',
+  },
+};

--- a/js/photo-import.js
+++ b/js/photo-import.js
@@ -1,0 +1,462 @@
+const OCR_LANGUAGES = 'eng+rus';
+const FIELD_KEYS = ['coffeeName', 'roasterName', 'origin', 'process', 'brewMethod', 'notes'];
+
+const FIELD_LABELS = {
+  coffeeName: 'Название кофе',
+  roasterName: 'Ростер',
+  origin: 'Происхождение',
+  process: 'Обработка',
+  brewMethod: 'Метод заваривания',
+  notes: 'Заметки',
+};
+
+const PROCESS_HINTS = ['natural', 'washed', 'honey', 'anaerobic', 'carbonic', 'experimental'];
+
+function $(selector) {
+  return document.querySelector(selector);
+}
+
+function byField(field, root) {
+  return root.querySelector(`[data-field="${field}"]`);
+}
+
+function normalizeText(value) {
+  return (value || '').replace(/\s+/g, ' ').trim();
+}
+
+function detectProcessFromLine(line) {
+  const lowered = line.toLowerCase();
+  if (/(honey|red honey|yellow honey|white honey|black honey|медов)/.test(lowered)) return 'Honey';
+  if (/(anaer|carbonic|мц|фермент|који|koji|wine|macera)/.test(lowered)) return 'Anaerobic';
+  if (/(wash|fully washed|мыта|мытый|вымыт|wet)/.test(lowered)) return 'Washed';
+  if (/(natur|dry|natural|натурал|сух)/.test(lowered)) return 'Natural';
+  if (/(experimental|ferment|double|triple|enzym)/.test(lowered)) return 'Experimental';
+  return '';
+}
+
+function parseFieldsFromText(rawText) {
+  const lines = String(rawText || '')
+    .split(/\r?\n/)
+    .map((line) => line.replace(/[\u2014\u2013]/g, '-').trim())
+    .filter(Boolean);
+
+  const extracted = {
+    coffeeName: '',
+    roasterName: '',
+    origin: '',
+    process: '',
+    brewMethod: '',
+    notes: '',
+  };
+
+  const usedLines = new Set();
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (!line.includes(':') && !line.includes('-')) continue;
+    const parts = line.split(/[:\-]/);
+    if (parts.length < 2) continue;
+    const label = normalizeText(parts[0]).toLowerCase();
+    const value = normalizeText(parts.slice(1).join('-'));
+    if (!value) continue;
+
+    if (!extracted.roasterName && /(roaster|roastery|обжар|rost)/.test(label)) {
+      extracted.roasterName = value;
+      usedLines.add(i);
+    } else if (!extracted.origin && /(origin|страна|country|регион|region)/.test(label)) {
+      extracted.origin = value;
+      usedLines.add(i);
+    } else if (!extracted.process && /(process|обработ|method|метод)/.test(label)) {
+      extracted.process = value;
+      usedLines.add(i);
+    } else if (!extracted.brewMethod && /(brew|brew method|завар|способ)/.test(label)) {
+      extracted.brewMethod = value;
+      usedLines.add(i);
+    } else if (!extracted.notes && /(notes|вкус|flavor|tasting|profile)/.test(label)) {
+      extracted.notes = value;
+      usedLines.add(i);
+    } else if (!extracted.coffeeName && /(coffee|название|lot|blend)/.test(label)) {
+      extracted.coffeeName = value;
+      usedLines.add(i);
+    }
+  }
+
+  if (!extracted.coffeeName && lines[0]) {
+    extracted.coffeeName = normalizeText(lines[0]);
+    usedLines.add(0);
+  }
+  if (!extracted.roasterName && lines[1] && !usedLines.has(1)) {
+    extracted.roasterName = normalizeText(lines[1]);
+    usedLines.add(1);
+  }
+
+  if (!extracted.process) {
+    const processLine = lines.find((line) => detectProcessFromLine(line));
+    if (processLine) extracted.process = detectProcessFromLine(processLine);
+  }
+
+  if (!extracted.notes) {
+    const last = lines[lines.length - 1];
+    if (last && !usedLines.has(lines.length - 1)) {
+      extracted.notes = normalizeText(last);
+    }
+  }
+
+  return extracted;
+}
+
+async function recognizeFile(file, onProgress) {
+  if (!file) throw new Error('Файл не выбран');
+  const { recognize } = await import('https://cdn.jsdelivr.net/npm/tesseract.js@4/dist/tesseract.esm.min.js');
+  const result = await recognize(file, OCR_LANGUAGES, {
+    logger: (payload) => {
+      if (payload.status === 'recognizing text' && typeof onProgress === 'function') {
+        const progress = payload.progress ? Math.round(payload.progress * 100) : 0;
+        onProgress(Math.min(progress, 100));
+      }
+    },
+  });
+  return result.data?.text || '';
+}
+
+function fillForm(formEl, values) {
+  FIELD_KEYS.forEach((field) => {
+    const input = byField(field, formEl);
+    if (input) input.value = values[field] || '';
+  });
+}
+
+function collectForm(formEl) {
+  const data = {};
+  FIELD_KEYS.forEach((field) => {
+    const input = byField(field, formEl);
+    data[field] = normalizeText(input?.value || '');
+  });
+  return data;
+}
+
+function buildPrefillUrl(data, config) {
+  if (!config?.enabled || !config.prefillBaseUrl) return '';
+  const params = new URLSearchParams(config.extraParams || {});
+  for (const [field, entryId] of Object.entries(config.entryMap || {})) {
+    if (!entryId) continue;
+    let value = '';
+    if (field === 'rawText') {
+      value = data.rawText || '';
+    } else {
+      value = data[field] || '';
+    }
+    if (value) params.append(entryId, value);
+  }
+  if (!params.toString()) return config.prefillBaseUrl;
+  return `${config.prefillBaseUrl}?${params.toString()}`;
+}
+
+function setStatus(statusEl, message, tone = 'neutral') {
+  if (!statusEl) return;
+  statusEl.textContent = message;
+  statusEl.dataset.tone = tone;
+}
+
+function setButtonsState(buttons, state) {
+  buttons.forEach((btn) => {
+    if (!btn) return;
+    btn.disabled = !state;
+  });
+}
+
+function formatClipboardData(data) {
+  const parts = [];
+  FIELD_KEYS.forEach((field) => {
+    const label = FIELD_LABELS[field];
+    const value = data[field];
+    if (value) {
+      parts.push(`${label}: ${value}`);
+    }
+  });
+  if (data.rawText) {
+    parts.push('', 'Распознанный текст:', data.rawText);
+  }
+  return parts.join('\n');
+}
+
+async function copyToClipboard(text) {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch (err) {
+    try {
+      const temp = document.createElement('textarea');
+      temp.value = text;
+      temp.setAttribute('readonly', '');
+      temp.style.position = 'absolute';
+      temp.style.left = '-9999px';
+      document.body.appendChild(temp);
+      temp.select();
+      document.execCommand('copy');
+      document.body.removeChild(temp);
+      return true;
+    } catch (copyErr) {
+      console.error('Clipboard copy failed:', copyErr);
+      return false;
+    }
+  }
+}
+
+export function initPhotoImport({ googleFormConfig } = {}) {
+  const card = $('#photoUploadCard');
+  const input = $('#photoUploadInput');
+  const statusEl = $('#photoOcrStatus');
+  const textEl = $('#photoOcrText');
+  const summaryEl = $('#photoOcrSummary');
+  const formEl = $('#photoDetailsForm');
+  const processHintEl = $('#photoProcessHint');
+  const copyBtn = $('#photoCopyData');
+  const sendBtn = $('#photoSendToDocs');
+  const hintEl = $('#photoDocsHint');
+
+  if (!card || !input || !statusEl || !textEl || !formEl) return;
+
+  let currentText = '';
+  let isProcessing = false;
+  let showFieldStatus = false;
+
+  const fieldWrappers = {};
+  const fieldStatusEls = {};
+  const fieldStates = {};
+  const recognizedValues = {};
+
+  FIELD_KEYS.forEach((field) => {
+    const fieldInput = formEl.querySelector(`[data-field="${field}"]`);
+    const wrapper = fieldInput?.closest('.photo-field');
+    if (wrapper) {
+      fieldWrappers[field] = wrapper;
+      fieldStatusEls[field] = wrapper.querySelector('.photo-field__status');
+    }
+    fieldStates[field] = 'empty';
+    recognizedValues[field] = '';
+  });
+
+  function resetFieldTracking() {
+    FIELD_KEYS.forEach((field) => {
+      fieldStates[field] = 'empty';
+      recognizedValues[field] = '';
+    });
+  }
+
+  function applyFieldStates() {
+    FIELD_KEYS.forEach((field) => {
+      const wrapper = fieldWrappers[field];
+      const statusNode = fieldStatusEls[field];
+      if (wrapper) {
+        if (showFieldStatus) {
+          wrapper.dataset.state = fieldStates[field];
+        } else {
+          delete wrapper.dataset.state;
+        }
+      }
+      if (statusNode) {
+        if (!showFieldStatus) {
+          statusNode.textContent = '';
+          statusNode.dataset.tone = '';
+        } else if (fieldStates[field] === 'auto') {
+          statusNode.textContent = 'Распознано автоматически';
+          statusNode.dataset.tone = 'auto';
+        } else if (fieldStates[field] === 'manual') {
+          statusNode.textContent = 'Заполнено вручную';
+          statusNode.dataset.tone = 'manual';
+        } else {
+          statusNode.textContent = 'Требуется ввод';
+          statusNode.dataset.tone = 'empty';
+        }
+      }
+    });
+  }
+
+  function updateSummary() {
+    if (!summaryEl) return;
+    if (!showFieldStatus) {
+      summaryEl.innerHTML = '<p class="photo-summary__placeholder">После распознавания здесь появится отчёт о том, какие поля заполнились автоматически.</p>';
+      return;
+    }
+
+    const autoFields = FIELD_KEYS.filter((field) => fieldStates[field] === 'auto');
+    const manualFields = FIELD_KEYS.filter((field) => fieldStates[field] === 'manual');
+    const emptyFields = FIELD_KEYS.filter((field) => fieldStates[field] === 'empty');
+
+    const sections = [];
+
+    if (autoFields.length) {
+      sections.push(`
+        <div class="photo-summary__section">
+          <span class="photo-summary__label" data-tone="auto">✅ Распознано автоматически</span>
+          <ul class="photo-summary__list">
+            ${autoFields.map((field) => `<li>${FIELD_LABELS[field]}</li>`).join('')}
+          </ul>
+        </div>
+      `);
+    }
+    if (manualFields.length) {
+      sections.push(`
+        <div class="photo-summary__section">
+          <span class="photo-summary__label" data-tone="manual">✏️ Изменено вручную</span>
+          <ul class="photo-summary__list">
+            ${manualFields.map((field) => `<li>${FIELD_LABELS[field]}</li>`).join('')}
+          </ul>
+        </div>
+      `);
+    }
+    if (emptyFields.length) {
+      sections.push(`
+        <div class="photo-summary__section">
+          <span class="photo-summary__label" data-tone="empty">⚠️ Нужно заполнить</span>
+          <ul class="photo-summary__list">
+            ${emptyFields.map((field) => `<li>${FIELD_LABELS[field]}</li>`).join('')}
+          </ul>
+        </div>
+      `);
+    }
+
+    if (!sections.length) {
+      summaryEl.innerHTML = '<p class="photo-summary__placeholder">Текст не распознан. Заполните поля вручную.</p>';
+    } else {
+      summaryEl.innerHTML = `<div class="photo-summary__sections">${sections.join('')}</div>`;
+    }
+  }
+
+  setStatus(statusEl, 'Файл пока не выбран. Загрузите фото этикетки с данными.');
+  textEl.value = '';
+  fillForm(formEl, {
+    coffeeName: '',
+    roasterName: '',
+    origin: '',
+    process: '',
+    brewMethod: '',
+    notes: '',
+  });
+  setButtonsState([copyBtn, sendBtn], false);
+  resetFieldTracking();
+  applyFieldStates();
+  updateSummary();
+
+  if (hintEl) {
+    if (googleFormConfig?.enabled && googleFormConfig.prefillBaseUrl) {
+      hintEl.textContent = 'Данные будут переданы в заранее заполненную форму Google при нажатии на кнопку.';
+    } else {
+      hintEl.textContent = 'Укажите параметры формы Google в файле js/config.js, чтобы включить автозаполнение.';
+    }
+  }
+
+  if (processHintEl) {
+    processHintEl.textContent = `Подсказка: поддерживаются обработки ${PROCESS_HINTS.join(', ')}.`;
+  }
+
+  input.addEventListener('change', async () => {
+    const file = input.files?.[0];
+    if (!file) {
+      setStatus(statusEl, 'Файл не выбран.', 'warning');
+      return;
+    }
+    try {
+      isProcessing = true;
+      showFieldStatus = false;
+      setStatus(statusEl, 'Распознавание текста…', 'progress');
+      setButtonsState([copyBtn, sendBtn], false);
+      resetFieldTracking();
+      applyFieldStates();
+      updateSummary();
+      const text = await recognizeFile(file, (progress) => {
+        setStatus(statusEl, `Распознавание текста… ${progress}%`, 'progress');
+      });
+      currentText = text.trim();
+      textEl.value = currentText;
+      const parsedFields = parseFieldsFromText(currentText);
+      fillForm(formEl, parsedFields);
+      FIELD_KEYS.forEach((field) => {
+        const value = normalizeText(parsedFields[field]);
+        recognizedValues[field] = value;
+        fieldStates[field] = value ? 'auto' : 'empty';
+      });
+      showFieldStatus = true;
+      applyFieldStates();
+      updateSummary();
+      setStatus(statusEl, 'Распознавание завершено. Проверьте и отредактируйте данные при необходимости.', 'success');
+      setButtonsState([copyBtn], Boolean(currentText));
+      if (googleFormConfig?.enabled && googleFormConfig.prefillBaseUrl) {
+        setButtonsState([sendBtn], Boolean(currentText));
+      }
+    } catch (err) {
+      console.error('OCR error:', err);
+      setStatus(statusEl, 'Не удалось распознать изображение. Попробуйте другое фото.', 'error');
+      textEl.value = '';
+      currentText = '';
+      resetFieldTracking();
+      showFieldStatus = true;
+      applyFieldStates();
+      updateSummary();
+      setButtonsState([copyBtn, sendBtn], false);
+    } finally {
+      isProcessing = false;
+    }
+  });
+
+  formEl.addEventListener('input', (event) => {
+    const target = event.target;
+    const field = target?.dataset?.field;
+    if (field && FIELD_KEYS.includes(field)) {
+      const rawValue = target.value || '';
+      const normalizedValue = normalizeText(rawValue);
+      if (!normalizedValue) {
+        fieldStates[field] = 'empty';
+      } else if (recognizedValues[field] && normalizedValue === recognizedValues[field]) {
+        fieldStates[field] = 'auto';
+      } else {
+        fieldStates[field] = 'manual';
+      }
+      showFieldStatus = true;
+      applyFieldStates();
+      updateSummary();
+    }
+
+    if (currentText || FIELD_KEYS.some((key) => normalizeText(formEl.querySelector(`[data-field="${key}"]`)?.value))) {
+      setButtonsState([copyBtn], true);
+      if (googleFormConfig?.enabled && googleFormConfig.prefillBaseUrl) {
+        setButtonsState([sendBtn], true);
+      }
+    }
+  });
+
+  copyBtn?.addEventListener('click', async () => {
+    if (!currentText && !isProcessing && !FIELD_KEYS.some((key) => normalizeText(formEl.querySelector(`[data-field="${key}"]`)?.value))) {
+      return;
+    }
+    const formData = collectForm(formEl);
+    const payload = {
+      ...formData,
+      rawText: currentText,
+    };
+    const formatted = formatClipboardData(payload);
+    const ok = await copyToClipboard(formatted);
+    if (ok) {
+      setStatus(statusEl, 'Данные скопированы в буфер обмена.', 'success');
+    } else {
+      setStatus(statusEl, 'Не удалось скопировать данные. Скопируйте их вручную из поля ниже.', 'warning');
+    }
+  });
+
+  sendBtn?.addEventListener('click', () => {
+    if (!googleFormConfig?.enabled || !googleFormConfig.prefillBaseUrl) return;
+    const formData = collectForm(formEl);
+    const payload = {
+      ...formData,
+      rawText: currentText,
+    };
+    const url = buildPrefillUrl(payload, googleFormConfig);
+    if (!url) {
+      setStatus(statusEl, 'Проверьте настройки Google формы в js/config.js.', 'warning');
+      return;
+    }
+    window.open(url, '_blank', 'noopener');
+    setStatus(statusEl, 'Открыта форма Google с предварительно заполненными данными.', 'success');
+  });
+}


### PR DESCRIPTION
## Summary
- add an OCR results summary panel that explains which coffee card fields were autofilled, edited, or still empty
- highlight form inputs with contextual badges so baristas can see what was recognized versus what requires attention
- keep action buttons available after manual entry and guard copy/send actions when no data is present

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf017775c08331b3f80b48e4267541