### PR TITLE
Add hint toggle to filter description

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -274,6 +274,44 @@ body[data-theme="dark"] .overlay-summary{
   gap:14px;
 }
 
+.overlay-hint{
+  display:flex;
+  align-items:flex-start;
+  gap:10px;
+}
+
+.overlay-info-toggle{
+  border:0;
+  padding:6px;
+  border-radius:50%;
+  background:var(--accent-soft);
+  color:var(--accent);
+  font-size:16px;
+  line-height:1;
+  cursor:pointer;
+  transition:background-color 0.2s ease,color 0.2s ease;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  flex-shrink:0;
+}
+
+.overlay-info-toggle:hover,
+.overlay-info-toggle:focus-visible{
+  background:var(--accent);
+  color:#fff;
+  outline:none;
+}
+
+.overlay-info-toggle:focus:not(:focus-visible){
+  outline:none;
+}
+
+.overlay-info-toggle[aria-expanded="true"]{
+  background:var(--accent);
+  color:#fff;
+}
+
 .overlay-description{
   margin:0;
   color:var(--muted);

--- a/js/app.js
+++ b/js/app.js
@@ -1,4 +1,4 @@
-import { debounce } from './utils.js';
+import { debounce, setupInfoDisclosure } from './utils.js';
 import { buildCityPoints, buildRouteFeatures, getVisitedCountriesIso2, loadData } from './data-loader.js';
 import { PROCESS_FILTER_VALUES, createUIController, renderAchievements } from './ui-controls.js';
 import { createMapController } from './map-init.js';
@@ -10,45 +10,10 @@ const theme = (new URLSearchParams(location.search).get('style') || 'light').toL
 document.body.dataset.theme = theme;
 const flagMode = (new URLSearchParams(location.search).get('flag') || 'img').toLowerCase();
 
-function setupInfoToggle() {
-  const toggle = document.querySelector('[data-map-info-toggle]');
-  const panel = document.querySelector('[data-map-info-panel]');
-  if (!toggle || !panel) return;
-
-  const closePanel = () => {
-    panel.hidden = true;
-    toggle.setAttribute('aria-expanded', 'false');
-  };
-
-  const openPanel = () => {
-    panel.hidden = false;
-    toggle.setAttribute('aria-expanded', 'true');
-  };
-
-  toggle.addEventListener('click', () => {
-    const expanded = toggle.getAttribute('aria-expanded') === 'true';
-    if (expanded) {
-      closePanel();
-    } else {
-      openPanel();
-    }
-  });
-
-  document.addEventListener('click', (event) => {
-    if (panel.hidden) return;
-    if (toggle.contains(event.target) || panel.contains(event.target)) return;
-    closePanel();
-  });
-
-  document.addEventListener('keydown', (event) => {
-    if (event.key !== 'Escape' || panel.hidden) return;
-    event.preventDefault();
-    closePanel();
-    toggle.focus();
-  });
-}
-
-setupInfoToggle();
+setupInfoDisclosure({
+  toggle: document.querySelector('[data-map-info-toggle]'),
+  panel: document.querySelector('[data-map-info-panel]'),
+});
 
 const mapController = createMapController({ accessToken: MAPBOX_TOKEN, theme, flagMode });
 const overlayMedia = window.matchMedia('(max-width: 720px)');

--- a/js/ui-controls.js
+++ b/js/ui-controls.js
@@ -1,4 +1,4 @@
-import { escapeAttr, escapeHtml } from './utils.js';
+import { escapeAttr, escapeHtml, setupInfoDisclosure } from './utils.js';
 
 export function processColors(pType) {
   switch (pType) {
@@ -69,8 +69,15 @@ function buildControlsHTML(pointsCount, countriesCount, hasOwner, ownerLabel = '
       </button>
     `;
   }).join('');
+  const infoId = 'filtersInfoText';
   wrap.innerHTML = `
-    <p class="overlay-description">Выбирайте, что подсветить на карте.</p>
+    <div class="overlay-hint">
+      <button type="button" class="overlay-info-toggle" aria-expanded="false" aria-controls="${infoId}" data-overlay-info-toggle>
+        <span aria-hidden="true">ℹ️</span>
+        <span class="sr-only">Показать описание фильтров</span>
+      </button>
+      <p class="overlay-description" id="${infoId}" data-overlay-info-panel hidden>Выбирайте, что подсветить на карте.</p>
+    </div>
     <div class="filters-stats">
       <span class="chip" title="Точек на карте">☕ <span id="pointsCount">${pointsCount}</span></span>
       <span class="chip" title="Стран в коллекции">🌍 <span id="countriesCount">${countriesCount}</span></span>
@@ -122,6 +129,13 @@ export function createUIController({
   const visitedToggle = root.querySelector('#toggleVisited');
   const mineToggle = root.querySelector('#toggleMine');
   const processButtons = [...root.querySelectorAll('[data-process]')];
+  const filtersInfoToggle = root.querySelector('[data-overlay-info-toggle]');
+  const filtersInfoPanel = root.querySelector('[data-overlay-info-panel]');
+
+  setupInfoDisclosure({
+    toggle: filtersInfoToggle,
+    panel: filtersInfoPanel,
+  });
 
   if (routesToggle) {
     routesToggle.addEventListener('change', (e) => onRoutesToggle?.(e.target.checked), { passive: true });

--- a/js/utils.js
+++ b/js/utils.js
@@ -102,3 +102,57 @@ export const debounce = (fn, ms = 150) => {
     timer = window.setTimeout(() => fn(...args), ms);
   };
 };
+
+export function setupInfoDisclosure({ toggle, panel, closeOnOutside = true } = {}) {
+  if (!toggle || !panel) return () => {};
+
+  const close = () => {
+    panel.hidden = true;
+    toggle.setAttribute('aria-expanded', 'false');
+  };
+
+  const open = () => {
+    panel.hidden = false;
+    toggle.setAttribute('aria-expanded', 'true');
+  };
+
+  const handleToggleClick = (event) => {
+    event.stopPropagation();
+    const expanded = toggle.getAttribute('aria-expanded') === 'true';
+    if (expanded) {
+      close();
+    } else {
+      open();
+    }
+  };
+
+  const handleDocumentClick = (event) => {
+    if (panel.hidden) return;
+    const target = event.target;
+    if (toggle.contains(target) || panel.contains(target)) return;
+    close();
+  };
+
+  const handleKeydown = (event) => {
+    if (event.key !== 'Escape' || panel.hidden) return;
+    event.preventDefault();
+    close();
+    if (typeof toggle.focus === 'function') {
+      toggle.focus();
+    }
+  };
+
+  toggle.addEventListener('click', handleToggleClick);
+  document.addEventListener('keydown', handleKeydown);
+  if (closeOnOutside) {
+    document.addEventListener('click', handleDocumentClick);
+  }
+
+  return () => {
+    toggle.removeEventListener('click', handleToggleClick);
+    document.removeEventListener('keydown', handleKeydown);
+    if (closeOnOutside) {
+      document.removeEventListener('click', handleDocumentClick);
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- add a reusable helper to manage info disclosure toggles
- show the filters description inside a hint button and wire it up with the helper
- style the new hint toggle in the filters overlay

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d52ba11c888331be2bb18930c7bafc