### PR TITLE
Fix OCR form field selection

### DIFF
--- a/js/photo-import.js
+++ b/js/photo-import.js
@@ -17,7 +17,9 @@ function $(selector) {
 }
 
 function byField(field, root) {
-  return root.querySelector(`[data-field="${field}"]`);
+  return root.querySelector(
+    `input[data-field="${field}"], textarea[data-field="${field}"], select[data-field="${field}"]`,
+  );
 }
 
 function normalizeText(value) {


### PR DESCRIPTION
## Summary
- ensure the photo import helper looks up actual form inputs when filling recognized values
- allow recognized OCR text to populate the visible form fields again

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d53924325c8331bf4fff41dbfa638e