### PR TITLE
Refine coffee photo OCR field mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Coffeemap-mapbox-googleshhets
 3. Отредактируйте `js/config.js`:
    - `enabled: true` — включить интеграцию.
    - `prefillBaseUrl` — ссылка вида `https://docs.google.com/forms/d/e/.../viewform`.
-   - `entryMap` — сопоставление ключей `coffeeName`, `roasterName`, `origin`, `process`, `brewMethod`, `notes`, `rawText` с идентификаторами полей формы.
+  - `entryMap` — сопоставление ключей `coffeeName`, `roasterName`, `country`, `region`, `farm`, `process`, `brewMethod`, `notes`, `rawText` с идентификаторами полей формы.
    - при необходимости укажите `extraParams` (по умолчанию `usp=pp_url`).
 
 После этого кнопка «Отправить в Google Docs» откроет форму с уже подставленными данными.

--- a/index.html
+++ b/index.html
@@ -69,10 +69,24 @@
               <span class="photo-field__status" data-role="status"></span>
             </label>
           </div>
-          <div class="photo-field" data-field="origin">
+          <div class="photo-field" data-field="country">
             <label>
-              <span>Происхождение</span>
-              <input type="text" data-field="origin" placeholder="Страна или регион" />
+              <span>Страна</span>
+              <input type="text" data-field="country" placeholder="Например, Kenya" />
+              <span class="photo-field__status" data-role="status"></span>
+            </label>
+          </div>
+          <div class="photo-field" data-field="region">
+            <label>
+              <span>Регион</span>
+              <input type="text" data-field="region" placeholder="Область, район или географическая зона" />
+              <span class="photo-field__status" data-role="status"></span>
+            </label>
+          </div>
+          <div class="photo-field" data-field="farm">
+            <label>
+              <span>Ферма / кооператив</span>
+              <input type="text" data-field="farm" placeholder="Ферма, станция обработки или кооператив" />
               <span class="photo-field__status" data-role="status"></span>
             </label>
           </div>

--- a/js/config.js
+++ b/js/config.js
@@ -12,7 +12,9 @@ export const GOOGLE_FORM_CONFIG = {
   entryMap: {
     coffeeName: '',
     roasterName: '',
-    origin: '',
+    country: '',
+    region: '',
+    farm: '',
     process: '',
     brewMethod: '',
     notes: '',


### PR DESCRIPTION
## Summary
- capture coffee country, region, and farm separately when parsing OCR output
- expand heuristics for detecting origin lines, filtering out variety names, and mapping to new form fields
- update the photo import form, Google Form mapping config, and docs to reflect the new location fields

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d545dc3f3c8331a0c6a29c79a2b528