### PR TITLE
Center overlay headings

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -274,6 +274,15 @@ body[data-theme="dark"] .overlay-summary{
   gap:14px;
 }
 
+.overlay-heading{
+  margin:0;
+  font-size:16px;
+  font-weight:600;
+  color:var(--text-primary);
+  text-align:center;
+  width:100%;
+}
+
 .overlay-hint{
   display:flex;
   align-items:flex-start;

--- a/index.html
+++ b/index.html
@@ -39,7 +39,10 @@
             <span class="overlay-title">Фильтры и слои</span>
             <span class="overlay-caret" aria-hidden="true"></span>
           </summary>
-          <div class="overlay-body" id="filtersPanel"></div>
+          <div class="overlay-body" role="region" aria-labelledby="filtersHeading">
+            <h2 class="overlay-heading" id="filtersHeading">Фильтры и слои</h2>
+            <div id="filtersPanel"></div>
+          </div>
         </details>
 
         <details class="overlay-card" id="achievementsMenu">
@@ -48,7 +51,8 @@
             <span class="overlay-title">Достижения</span>
             <span class="overlay-caret" aria-hidden="true"></span>
           </summary>
-          <div class="overlay-body">
+          <div class="overlay-body" role="region" aria-labelledby="achievementsHeading">
+            <h2 class="overlay-heading" id="achievementsHeading">Достижения</h2>
             <p class="overlay-description">Следите за прогрессом дегустаций и открывайте новые бейджи.</p>
             <div class="achievements" id="achievements"></div>
           </div>


### PR DESCRIPTION
## Summary
- center the overlay headings and stretch them to span the overlay width for better visibility

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6871e5a8c833183a0a9720f147cb1