### PR TITLE
Align filter hint icon with heading

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -280,19 +280,18 @@ body[data-theme="dark"] .overlay-summary{
   gap:12px;
 }
 
+.overlay-heading-row{
+  display:flex;
+  align-items:center;
+  gap:12px;
+}
+
 .overlay-heading{
   margin:0;
   font-size:16px;
   font-weight:600;
   color:var(--text-primary);
-  text-align:center;
-  width:100%;
-}
-
-.overlay-hint{
-  display:flex;
-  align-items:flex-start;
-  gap:8px;
+  flex:1;
 }
 
 .overlay-info-toggle{

--- a/index.html
+++ b/index.html
@@ -40,7 +40,14 @@
             <span class="overlay-caret" aria-hidden="true"></span>
           </summary>
           <div class="overlay-body" role="region" aria-labelledby="filtersHeading">
-            <h2 class="overlay-heading" id="filtersHeading">Фильтры и слои</h2>
+            <div class="overlay-heading-row">
+              <h2 class="overlay-heading" id="filtersHeading">Фильтры и слои</h2>
+              <button class="overlay-info-toggle" type="button" aria-expanded="false" aria-controls="filtersInfoText" data-overlay-info-toggle>
+                <span aria-hidden="true">ℹ️</span>
+                <span class="sr-only">Показать описание фильтров</span>
+              </button>
+            </div>
+            <p class="overlay-description" id="filtersInfoText" data-overlay-info-panel hidden>Выбирайте, что подсветить на карте.</p>
             <div id="filtersPanel"></div>
           </div>
         </details>

--- a/js/ui-controls.js
+++ b/js/ui-controls.js
@@ -69,15 +69,7 @@ function buildControlsHTML(pointsCount, countriesCount, hasOwner, ownerLabel = '
       </button>
     `;
   }).join('');
-  const infoId = 'filtersInfoText';
   wrap.innerHTML = `
-    <div class="overlay-hint">
-      <button type="button" class="overlay-info-toggle" aria-expanded="false" aria-controls="${infoId}" data-overlay-info-toggle>
-        <span aria-hidden="true">ℹ️</span>
-        <span class="sr-only">Показать описание фильтров</span>
-      </button>
-      <p class="overlay-description" id="${infoId}" data-overlay-info-panel hidden>Выбирайте, что подсветить на карте.</p>
-    </div>
     <div class="filters-stats">
       <span class="chip" title="Точек на карте">☕ <span id="pointsCount">${pointsCount}</span></span>
       <span class="chip" title="Стран в коллекции">🌍 <span id="countriesCount">${countriesCount}</span></span>
@@ -129,8 +121,9 @@ export function createUIController({
   const visitedToggle = root.querySelector('#toggleVisited');
   const mineToggle = root.querySelector('#toggleMine');
   const processButtons = [...root.querySelectorAll('[data-process]')];
-  const filtersInfoToggle = root.querySelector('[data-overlay-info-toggle]');
-  const filtersInfoPanel = root.querySelector('[data-overlay-info-panel]');
+  const filtersMenu = document.getElementById('filtersMenu');
+  const filtersInfoToggle = filtersMenu?.querySelector('[data-overlay-info-toggle]');
+  const filtersInfoPanel = filtersMenu?.querySelector('[data-overlay-info-panel]');
 
   setupInfoDisclosure({
     toggle: filtersInfoToggle,


### PR DESCRIPTION
## Summary
- move the filters hint button next to the overlay heading and show the description below it
- update the layout styles to align the heading and info button on one row
- adjust the filters UI builder to rely on the new static markup while keeping the toggle behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6c2ac5cbc83318769ea2469334b1e