### PR TITLE
Adjust map banner width and padding

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -123,13 +123,13 @@ body[data-theme="dark"]{
   border:1px solid var(--surface-border);
   box-shadow:var(--surface-shadow);
   backdrop-filter:blur(18px);
-  padding:18px 20px;
+  padding:14px 20px;
   font-family:var(--font-card);
   display:flex;
   flex-direction:column;
-  gap:8px;
-  max-width:360px;
-  width:min(360px,100%);
+  gap:6px;
+  max-width:440px;
+  width:min(440px,100%);
   pointer-events:auto;
 }
 


### PR DESCRIPTION
## Summary
- expand the map banner width so the full title displays without ellipsis
- tighten the banner's padding and spacing to reduce its overall height

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6c262c09c83319feabeed4173af40