### PR TITLE
Fix my records filter label

### DIFF
--- a/js/ui-controls.js
+++ b/js/ui-controls.js
@@ -49,9 +49,7 @@ function buildControlsHTML(pointsCount, countriesCount, hasOwner, ownerLabel = '
   wrap.className = 'filters-stack';
   const ownerLabelSafe = String(ownerLabel || '').trim();
   const mineLabelClass = hasOwner ? 'toggle-control' : 'toggle-control is-disabled';
-  const mineLabelText = hasOwner
-    ? (ownerLabelSafe ? `Мои записи (${ownerLabelSafe})` : 'Мои записи')
-    : 'Мои записи';
+  const mineLabelText = 'Мои записи';
   const mineTitleText = hasOwner
     ? (ownerLabelSafe ? `Показывать только свои записи — ${ownerLabelSafe}` : 'Показывать только свои записи')
     : 'Фильтр появится, когда в данных указан автор';


### PR DESCRIPTION
## Summary
- ensure the "Мои записи" filter label no longer appends owner name and always shows the base text

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d943ac19148331bbb5dfca81fd7e63