### PR TITLE
Reduce popup image dimensions on mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -866,6 +866,14 @@ input[type="checkbox"]{
     gap:10px;
   }
 
+  .popup-card{
+    width:280px;
+  }
+
+  .popup-cover-box{
+    height:150px;
+  }
+
   .map-banner{
     padding:14px 16px;
     border-radius:18px;
@@ -930,5 +938,13 @@ input[type="checkbox"]{
 
   .map-overlays{
     max-height:55vh;
+  }
+
+  .popup-card{
+    width:260px;
+  }
+
+  .popup-cover-box{
+    height:135px;
   }
 }


### PR DESCRIPTION
## Summary
- shrink popup cards and cover heights for screens under 420px and 360px
- ensure popup imagery takes up less vertical space on small devices

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d95b5e25cc8331b6c21fd2300a0f26