### PR TITLE
Improve filter overlay usability on mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -905,9 +905,28 @@ input[type="checkbox"]{
 
   .map-overlays{
     gap:10px;
-    max-height:60vh;
+    max-height:clamp(340px,calc(100vh - 160px),80vh);
     overflow:auto;
     padding-bottom:env(safe-area-inset-bottom);
+  }
+
+  @supports(height:100dvh){
+    .map-overlays{
+      max-height:clamp(340px,calc(100dvh - 160px),80dvh);
+    }
+  }
+
+  .overlay-card[open] .overlay-body{
+    max-height:clamp(260px,calc(100vh - 220px),520px);
+    overflow:auto;
+    -webkit-overflow-scrolling:touch;
+    overscroll-behavior:contain;
+  }
+
+  @supports(height:100dvh){
+    .overlay-card[open] .overlay-body{
+      max-height:clamp(260px,calc(100dvh - 220px),520px);
+    }
   }
 
   .overlay-card{


### PR DESCRIPTION
## Summary
- allow the overlay column to grow taller on phones by basing its max height on the viewport
- let the open filter panel scroll independently on mobile so all controls remain reachable

## Testing
- Not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68da7a82e3608331bafb62a6105af636