### PR TITLE
Narrow filter overlay width

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -208,13 +208,13 @@ body[data-theme="dark"]{
   display:flex;
   flex-direction:column;
   gap:12px;
-  width:min(260px,100%);
+  width:min(220px,100%);
   pointer-events:auto;
 }
 
 .overlay-card{
   width:100%;
-  max-width:260px;
+  max-width:220px;
   background:var(--surface);
   border:1px solid var(--surface-border);
   border-radius:18px;


### PR DESCRIPTION
## Summary
- reduce the default width of the filters sidebar to occupy less horizontal space
- keep overlay cards aligned with the new sidebar width for a tighter layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da846d7cb0833185012542f1e1a947