### PR TITLE
Revamp achievement badges and tooltips

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -648,37 +648,88 @@ input[type="checkbox"]{
   accent-color:var(--accent);
 }
 
+
 .achievements{
-  display:flex;
-  flex-wrap:wrap;
-  gap:10px;
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(160px,1fr));
+  gap:14px;
 }
 
 .ach-badge{
-  display:inline-flex;
-  align-items:center;
-  gap:8px;
-  padding:10px 14px;
-  border-radius:999px;
-  border:1px solid var(--surface-border);
-  background:var(--surface-strong);
-  font-size:13px;
-  line-height:1.2;
-  color:var(--text);
-  box-shadow:inset 0 0 0 1px rgba(255,255,255,0.06);
-  max-width:100%;
-  flex-wrap:wrap;
-  justify-content:center;
-  text-align:center;
-  overflow-wrap:anywhere;
+  position:relative;
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+  padding:16px 18px 18px;
+  border-radius:20px;
+  border:1px solid var(--ach-border,var(--surface-border));
+  background:var(--ach-bg,var(--surface-strong));
+  color:var(--ach-text,var(--text));
+  box-shadow:0 18px 30px -25px rgba(17,24,39,0.4);
+  transition:transform 0.2s ease, box-shadow 0.2s ease;
+  outline:0;
 }
 
-.ach-emoji{
-  font-size:16px;
+.ach-badge:hover,
+.ach-badge:focus-visible{
+  transform:translateY(-2px);
+  box-shadow:0 24px 38px -26px rgba(17,24,39,0.45);
+}
+
+.ach-icon{
+  width:48px;
+  height:48px;
+  border-radius:50%;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  font-size:24px;
+  background:rgba(255,255,255,0.65);
+  box-shadow:inset 0 0 0 1px rgba(255,255,255,0.6),0 6px 12px -8px rgba(15,23,42,0.4);
+}
+
+body[data-theme="dark"] .ach-icon{
+  background:rgba(15,23,42,0.35);
+  box-shadow:inset 0 0 0 1px rgba(255,255,255,0.18),0 6px 12px -8px rgba(0,0,0,0.75);
 }
 
 .ach-title{
   font-weight:600;
+  font-size:15px;
+  line-height:1.3;
+}
+
+.ach-badge::after{
+  content:attr(data-tooltip);
+  position:absolute;
+  left:50%;
+  bottom:-12px;
+  transform:translate(-50%,10px);
+  padding:10px 12px;
+  border-radius:12px;
+  background:var(--surface-strong);
+  color:var(--text);
+  border:1px solid var(--surface-border);
+  box-shadow:0 12px 20px -18px rgba(17,24,39,0.6);
+  font-size:13px;
+  line-height:1.35;
+  white-space:normal;
+  width:max-content;
+  max-width:220px;
+  opacity:0;
+  pointer-events:none;
+  transition:opacity 0.18s ease, transform 0.18s ease;
+  z-index:10;
+}
+
+.ach-badge:hover::after,
+.ach-badge:focus-visible::after{
+  opacity:1;
+  transform:translate(-50%,0);
+}
+
+.ach-badge[data-tooltip=""]::after{
+  display:none;
 }
 
 .ach-empty{

--- a/index.html
+++ b/index.html
@@ -60,7 +60,6 @@
           </summary>
           <div class="overlay-body" role="region" aria-labelledby="achievementsHeading">
             <h2 class="overlay-heading" id="achievementsHeading">Достижения</h2>
-            <p class="overlay-description">Следите за прогрессом дегустаций и открывайте новые бейджи.</p>
             <div class="achievements" id="achievements"></div>
           </div>
         </details>

--- a/js/ui-controls.js
+++ b/js/ui-controls.js
@@ -24,9 +24,30 @@ export const PROCESS_FILTERS = [
 export const PROCESS_FILTER_VALUES = new Set(PROCESS_FILTERS.map((p) => p.value));
 
 const ACHIEVEMENTS = [
-  { id: 'first_sip',   emoji: '🎉', title: 'Первая отметка',          color: { bg: '#d1fae5', br: '#99f6e4', txt: '#065f46' }, earned: (m) => m.total >= 1 },
-  { id: 'countries_3', emoji: '🧭', title: 'Три страны в коллекции',  color: { bg: '#fef3c7', br: '#fde68a', txt: '#92400e' }, earned: (m) => m.countries >= 3 },
-  { id: 'processes_3', emoji: '🔬', title: 'Три способа обработки',    color: { bg: '#ede9fe', br: '#ddd6fe', txt: '#4c1d95' }, earned: (m) => m.processTypes >= 3 },
+  {
+    id: 'first_sip',
+    emoji: '🎉',
+    title: 'Первая отметка',
+    description: 'Запишите первую дегустацию на карте.',
+    color: { bg: '#f0fdf4', br: '#bbf7d0', txt: '#14532d' },
+    earned: (m) => m.total >= 1,
+  },
+  {
+    id: 'countries_3',
+    emoji: '🧭',
+    title: 'Три страны в коллекции',
+    description: 'Попробуйте кофе минимум из трёх разных стран.',
+    color: { bg: '#fffbeb', br: '#fde68a', txt: '#78350f' },
+    earned: (m) => m.countries >= 3,
+  },
+  {
+    id: 'processes_3',
+    emoji: '🔬',
+    title: 'Три способа обработки',
+    description: 'Откройте дегустации с тремя разными методами обработки.',
+    color: { bg: '#f5f3ff', br: '#ddd6fe', txt: '#3730a3' },
+    earned: (m) => m.processTypes >= 3,
+  },
 ];
 
 export function renderAchievements(metrics) {
@@ -37,11 +58,18 @@ export function renderAchievements(metrics) {
     el.innerHTML = '<p class="ach-empty">Продолжайте исследовать карту, чтобы открыть новые бейджи.</p>';
     return;
   }
-  el.innerHTML = earned.map((achievement) => `
-    <div class="ach-badge" style="background:${achievement.color.bg};border-color:${achievement.color.br};color:${achievement.color.txt}" title="${escapeAttr(achievement.title)}">
-      <span class="ach-emoji">${achievement.emoji}</span><span class="ach-title">${achievement.title}</span>
-    </div>
-  `).join('');
+  el.innerHTML = earned.map((achievement) => {
+    const tooltip = achievement.description ? ` data-tooltip="${escapeAttr(achievement.description)}"` : '';
+    const aria = achievement.description
+      ? `${achievement.title}. ${achievement.description}`
+      : achievement.title;
+    return `
+      <div class="ach-badge" style="--ach-bg:${escapeAttr(achievement.color.bg)};--ach-border:${escapeAttr(achievement.color.br)};--ach-text:${escapeAttr(achievement.color.txt)}"${tooltip} tabindex="0" aria-label="${escapeAttr(aria)}">
+        <span class="ach-icon" aria-hidden="true">${achievement.emoji}</span>
+        <span class="ach-title">${escapeHtml(achievement.title)}</span>
+      </div>
+    `;
+  }).join('');
 }
 
 function buildControlsHTML(pointsCount, countriesCount, hasOwner, ownerLabel = '', activeProcess = 'all') {


### PR DESCRIPTION
## Summary
- remove the static achievements description beneath the hint icon
- redesign achievement badges with improved styling and hover tooltips for descriptions
- enrich achievement metadata with descriptions for accessible hover states

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68da884d35a08331bd028eaedbfc9b00