### PR TITLE
Reduce initial globe zoom level

### DIFF
--- a/js/map-init.js
+++ b/js/map-init.js
@@ -121,7 +121,7 @@ export function createMapController({ accessToken, theme, flagMode }) {
     container: 'map',
     style: theme === 'dark' ? 'mapbox://styles/mapbox/dark-v11' : 'mapbox://styles/mapbox/light-v11',
     center: [12, 20],
-    zoom: 2.2,
+    zoom: 1.6,
     attributionControl: true,
     renderWorldCopies: false,
   });


### PR DESCRIPTION
## Summary
- decrease the initial Mapbox map zoom so the globe renders at a smaller scale on load

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68dace4509a88331b5feb296ba9eb09c