### PR TITLE
Adjust map banner layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -123,11 +123,11 @@ body[data-theme="dark"]{
   border:1px solid var(--surface-border);
   box-shadow:var(--surface-shadow);
   backdrop-filter:blur(18px);
-  padding:14px 20px;
+  padding:10px 16px;
   font-family:var(--font-card);
   display:flex;
   flex-direction:column;
-  gap:6px;
+  gap:4px;
   max-width:440px;
   width:min(440px,100%);
   pointer-events:auto;
@@ -136,8 +136,8 @@ body[data-theme="dark"]{
 .map-title-row{
   display:flex;
   align-items:center;
-  justify-content:center;
-  gap:12px;
+  justify-content:flex-start;
+  gap:8px;
   flex-wrap:nowrap;
 }
 
@@ -146,7 +146,7 @@ body[data-theme="dark"]{
   font-weight:700;
   color:var(--text);
   flex:1;
-  text-align:center;
+  text-align:left;
   white-space:nowrap;
   overflow:hidden;
   text-overflow:ellipsis;


### PR DESCRIPTION
## Summary
- align the map banner title to the left to remove the leading empty space
- reduce padding and gaps in the banner to make the header more compact

## Testing
- No tests were run (not requested).


------
https://chatgpt.com/codex/tasks/task_e_68dace33d5c88331b8ad7da1ea4a34bb