### PR TITLE
Move achievements badges to top-right icons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -109,15 +109,20 @@ body[data-theme="dark"]{
   top:24px;
   left:24px;
   right:24px;
-  display:flex;
+  display:grid;
+  grid-template-columns:minmax(0,1fr) auto;
+  grid-template-rows:auto auto;
+  grid-template-areas:
+    "banner achievements"
+    "banner overlays";
   gap:16px;
-  align-items:flex-start;
-  flex-wrap:wrap;
+  align-items:start;
   pointer-events:none;
   z-index:2;
 }
 
 .map-banner{
+  grid-area:banner;
   background:var(--surface);
   border-radius:20px;
   border:1px solid var(--surface-border);
@@ -204,12 +209,33 @@ body[data-theme="dark"]{
 }
 
 .map-overlays{
-  margin-left:auto;
+  grid-area:overlays;
   display:flex;
   flex-direction:column;
   gap:12px;
   width:min(220px,100%);
+  justify-self:end;
   pointer-events:auto;
+}
+
+.map-achievements{
+  grid-area:achievements;
+  display:flex;
+  flex-direction:column;
+  align-items:flex-end;
+  gap:6px;
+  pointer-events:auto;
+}
+
+.map-achievements[hidden]{
+  display:none;
+}
+
+.achievements{
+  display:flex;
+  flex-wrap:wrap;
+  justify-content:flex-end;
+  gap:8px;
 }
 
 .overlay-card{
@@ -649,23 +675,18 @@ input[type="checkbox"]{
 }
 
 
-.achievements{
-  display:grid;
-  grid-template-columns:repeat(auto-fit,minmax(160px,1fr));
-  gap:14px;
-}
-
 .ach-badge{
   position:relative;
   display:flex;
-  flex-direction:column;
-  gap:12px;
-  padding:16px 18px 18px;
-  border-radius:20px;
+  align-items:center;
+  justify-content:center;
+  width:48px;
+  height:48px;
+  border-radius:16px;
   border:1px solid var(--ach-border,var(--surface-border));
   background:var(--ach-bg,var(--surface-strong));
   color:var(--ach-text,var(--text));
-  box-shadow:0 18px 30px -25px rgba(17,24,39,0.4);
+  box-shadow:0 12px 24px -16px rgba(17,24,39,0.4);
   transition:transform 0.2s ease, box-shadow 0.2s ease;
   outline:0;
 }
@@ -677,15 +698,15 @@ input[type="checkbox"]{
 }
 
 .ach-icon{
-  width:48px;
-  height:48px;
+  width:32px;
+  height:32px;
   border-radius:50%;
   display:flex;
   align-items:center;
   justify-content:center;
-  font-size:24px;
+  font-size:20px;
   background:rgba(255,255,255,0.65);
-  box-shadow:inset 0 0 0 1px rgba(255,255,255,0.6),0 6px 12px -8px rgba(15,23,42,0.4);
+  box-shadow:inset 0 0 0 1px rgba(255,255,255,0.6),0 4px 10px -6px rgba(15,23,42,0.4);
 }
 
 body[data-theme="dark"] .ach-icon{
@@ -693,18 +714,12 @@ body[data-theme="dark"] .ach-icon{
   box-shadow:inset 0 0 0 1px rgba(255,255,255,0.18),0 6px 12px -8px rgba(0,0,0,0.75);
 }
 
-.ach-title{
-  font-weight:600;
-  font-size:15px;
-  line-height:1.3;
-}
-
 .ach-badge::after{
   content:attr(data-tooltip);
   position:absolute;
-  left:50%;
+  right:0;
   bottom:-12px;
-  transform:translate(-50%,10px);
+  transform:translate(0,10px);
   padding:10px 12px;
   border-radius:12px;
   background:var(--surface-strong);
@@ -725,18 +740,11 @@ body[data-theme="dark"] .ach-icon{
 .ach-badge:hover::after,
 .ach-badge:focus-visible::after{
   opacity:1;
-  transform:translate(-50%,0);
+  transform:translate(0,0);
 }
 
 .ach-badge[data-tooltip=""]::after{
   display:none;
-}
-
-.ach-empty{
-  margin:0;
-  color:var(--muted);
-  font-size:14px;
-  line-height:1.45;
 }
 
 #map{
@@ -857,6 +865,7 @@ body[data-theme="dark"] .ach-icon{
     top:16px;
     left:16px;
     right:16px;
+    display:flex;
     flex-direction:column;
     align-items:stretch;
     gap:12px;
@@ -866,9 +875,16 @@ body[data-theme="dark"] .ach-icon{
     max-width:none;
   }
 
+  .map-achievements{
+    align-items:flex-start;
+  }
+
+  .achievements{
+    justify-content:flex-start;
+  }
+
   .map-overlays{
     width:100%;
-    margin-left:0;
   }
 
   .overlay-card{

--- a/index.html
+++ b/index.html
@@ -52,17 +52,10 @@
           </div>
         </details>
 
-        <details class="overlay-card" id="achievementsMenu">
-          <summary class="overlay-summary">
-            <span class="overlay-icon">🏆</span>
-            <span class="overlay-title">Достижения</span>
-            <span class="overlay-caret" aria-hidden="true"></span>
-          </summary>
-          <div class="overlay-body" role="region" aria-labelledby="achievementsHeading">
-            <h2 class="overlay-heading" id="achievementsHeading">Достижения</h2>
-            <div class="achievements" id="achievements"></div>
-          </div>
-        </details>
+      </div>
+      <div class="map-achievements" data-achievements-container hidden>
+        <span class="sr-only" id="achievementsLabel">Достижения</span>
+        <div class="achievements" id="achievements" role="list" aria-labelledby="achievementsLabel"></div>
       </div>
     </div>
   </div>

--- a/js/ui-controls.js
+++ b/js/ui-controls.js
@@ -53,20 +53,22 @@ const ACHIEVEMENTS = [
 export function renderAchievements(metrics) {
   const earned = ACHIEVEMENTS.filter((achievement) => achievement.earned(metrics));
   const el = document.getElementById('achievements');
+  const container = el?.closest('[data-achievements-container]');
   if (!el) return;
   if (!earned.length) {
-    el.innerHTML = '<p class="ach-empty">Продолжайте исследовать карту, чтобы открыть новые бейджи.</p>';
+    el.innerHTML = '';
+    if (container) container.hidden = true;
     return;
   }
+  if (container) container.hidden = false;
   el.innerHTML = earned.map((achievement) => {
     const tooltip = achievement.description ? ` data-tooltip="${escapeAttr(achievement.description)}"` : '';
     const aria = achievement.description
       ? `${achievement.title}. ${achievement.description}`
       : achievement.title;
     return `
-      <div class="ach-badge" style="--ach-bg:${escapeAttr(achievement.color.bg)};--ach-border:${escapeAttr(achievement.color.br)};--ach-text:${escapeAttr(achievement.color.txt)}"${tooltip} tabindex="0" aria-label="${escapeAttr(aria)}">
+      <div class="ach-badge" role="listitem" style="--ach-bg:${escapeAttr(achievement.color.bg)};--ach-border:${escapeAttr(achievement.color.br)};--ach-text:${escapeAttr(achievement.color.txt)}"${tooltip} tabindex="0" aria-label="${escapeAttr(aria)}">
         <span class="ach-icon" aria-hidden="true">${achievement.emoji}</span>
-        <span class="ach-title">${escapeHtml(achievement.title)}</span>
       </div>
     `;
   }).join('');


### PR DESCRIPTION
## Summary
- reposition the achievements area as a top-right icon row with accessible markup
- restyle the map UI layout and badges to support the new icon presentation across breakpoints
- update achievement rendering to hide text labels, rely on tooltips, and suppress the section when empty

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dad3b08dac8331b082477f97ee5341