### PR TITLE
Sort achievements by progress and visualize partial completion

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -727,22 +727,49 @@ input[type="checkbox"]{
   align-items:center;
   justify-content:center;
   font-size:20px;
+  position:relative;
+  z-index:1;
+  overflow:hidden;
+  color:inherit;
+}
+
+.ach-icon::before,
+.ach-icon::after{
+  content:"";
+  position:absolute;
+  inset:0;
+  border-radius:inherit;
+  transition:transform 0.25s ease;
+}
+
+.ach-icon::before{
   background:rgba(255,255,255,0.65);
   box-shadow:inset 0 0 0 1px rgba(255,255,255,0.6),0 4px 10px -6px rgba(15,23,42,0.4);
-  position:relative;
+  z-index:0;
+}
+
+.ach-icon::after{
+  background:var(--ach-bg,var(--surface-strong));
+  transform-origin:bottom center;
+  transform:scaleY(var(--ach-progress,1));
   z-index:1;
 }
 
-body[data-theme="dark"] .ach-icon{
+.ach-icon-emoji{
+  position:relative;
+  z-index:2;
+}
+
+body[data-theme="dark"] .ach-icon::before{
   background:rgba(15,23,42,0.35);
   box-shadow:inset 0 0 0 1px rgba(255,255,255,0.18),0 6px 12px -8px rgba(0,0,0,0.75);
 }
 
-.ach-badge.is-partial .ach-icon{
+.ach-badge.is-partial .ach-icon::before{
   background:rgba(255,255,255,0.8);
 }
 
-body[data-theme="dark"] .ach-badge.is-partial .ach-icon{
+body[data-theme="dark"] .ach-badge.is-partial .ach-icon::before{
   background:rgba(15,23,42,0.45);
 }
 


### PR DESCRIPTION
## Summary
- sort the achievements list so completed badges appear first, followed by higher progress items
- layer the achievement icon markup to support a progress fill overlay
- animate partial completion by filling the badge icon background according to progress

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbe52bb79083318a624fc0a403e5aa