### PR TITLE
Improve achievement visibility and tooltip layering

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -687,6 +687,7 @@ input[type="checkbox"]{
 
 .ach-badge{
   --ach-progress:1;
+  --ach-cover:0;
   position:relative;
   display:flex;
   align-items:center;
@@ -701,12 +702,14 @@ input[type="checkbox"]{
   transition:transform 0.2s ease, box-shadow 0.2s ease;
   outline:0;
   overflow:visible;
+  z-index:0;
 }
 
 .ach-badge:hover,
 .ach-badge:focus-visible{
   transform:translateY(-2px);
   box-shadow:0 24px 38px -26px rgba(17,24,39,0.45);
+  z-index:20;
 }
 
 .ach-badge::before{
@@ -716,7 +719,7 @@ input[type="checkbox"]{
   border-radius:inherit;
   background:var(--ach-bg,var(--surface-strong));
   transform-origin:bottom center;
-  transform:scaleY(var(--ach-progress,1));
+  transform:scaleY(var(--ach-cover,0));
   transition:transform 0.25s ease;
   z-index:0;
 }
@@ -753,7 +756,7 @@ input[type="checkbox"]{
 .ach-icon::after{
   background:var(--ach-bg,var(--surface-strong));
   transform-origin:bottom center;
-  transform:scaleY(var(--ach-progress,1));
+  transform:scaleY(var(--ach-cover,0));
   z-index:1;
 }
 
@@ -795,7 +798,7 @@ body[data-theme="dark"] .ach-badge.is-partial .ach-icon::before{
   opacity:0;
   pointer-events:none;
   transition:opacity 0.18s ease, transform 0.18s ease;
-  z-index:10;
+  z-index:200;
   overflow-wrap:anywhere;
   text-align:left;
 }

--- a/js/ui-controls.js
+++ b/js/ui-controls.js
@@ -352,7 +352,8 @@ export function renderAchievements(metrics) {
       ariaParts.push(`Прогресс ${progressPercent}%.`);
     }
     const aria = ariaParts.join(' ');
-    const styleValue = `--ach-bg:${achievement.color.bg};--ach-border:${achievement.color.br};--ach-text:${achievement.color.txt};--ach-progress:${achievement.progress.toFixed(3)}`;
+    const cover = Math.max(0, Math.min(1, 1 - achievement.progress));
+    const styleValue = `--ach-bg:${achievement.color.bg};--ach-border:${achievement.color.br};--ach-text:${achievement.color.txt};--ach-progress:${achievement.progress.toFixed(3)};--ach-cover:${cover.toFixed(3)}`;
     const style = ` style="${escapeAttr(styleValue)}"`;
     const cls = ['ach-badge'];
     if (achievement.earned) cls.push('is-earned');


### PR DESCRIPTION
## Summary
- invert partial achievement overlays so badges open up as progress grows
- raise achievement tooltips above badges and neighbouring items for unobstructed reading

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbee439a008331a7685590859f6a59