### PR TITLE
Improve achievement badge visibility

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -701,7 +701,7 @@ input[type="checkbox"]{
   box-shadow:0 12px 24px -16px rgba(17,24,39,0.4);
   transition:transform 0.2s ease, box-shadow 0.2s ease;
   outline:0;
-  overflow:visible;
+  overflow:hidden;
   z-index:0;
 }
 
@@ -719,7 +719,7 @@ input[type="checkbox"]{
   border-radius:inherit;
   background:var(--ach-bg,var(--surface-strong));
   transform-origin:bottom center;
-  transform:scaleY(var(--ach-cover,0));
+  transform:scaleY(var(--ach-progress,1));
   transition:transform 0.25s ease;
   z-index:0;
 }
@@ -748,16 +748,16 @@ input[type="checkbox"]{
 }
 
 .ach-icon::before{
-  background:rgba(255,255,255,0.65);
+  background:rgba(255,255,255,0.55);
   box-shadow:inset 0 0 0 1px rgba(255,255,255,0.6),0 4px 10px -6px rgba(15,23,42,0.4);
-  z-index:0;
+  z-index:1;
 }
 
 .ach-icon::after{
   background:var(--ach-bg,var(--surface-strong));
   transform-origin:bottom center;
-  transform:scaleY(var(--ach-cover,0));
-  z-index:1;
+  transform:scaleY(var(--ach-progress,1));
+  z-index:0;
 }
 
 .ach-icon-emoji{

--- a/js/ui-controls.js
+++ b/js/ui-controls.js
@@ -360,7 +360,9 @@ export function renderAchievements(metrics) {
     if (isPartial) cls.push('is-partial');
     return `
       <div class="${cls.join(' ')}" role="listitem"${style} tabindex="0" aria-label="${escapeAttr(aria)}">
-        <span class="ach-icon" aria-hidden="true">${achievement.emoji}</span>
+        <span class="ach-icon" aria-hidden="true">
+          <span class="ach-icon-emoji">${achievement.emoji}</span>
+        </span>
         ${tooltipHtml}
       </div>
     `;


### PR DESCRIPTION
## Summary
- ensure achievement emojis render above visual overlays by wrapping them in a dedicated element
- adjust badge styling so earned colors are fully visible and partial progress is shown proportionally

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbf40008d48331ab58d175f7923e15