### PR TITLE
Fix achievement tooltip hover visibility

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -719,7 +719,7 @@ input[type="checkbox"]{
   border-radius:inherit;
   background:var(--ach-bg,var(--surface-strong));
   transform-origin:bottom center;
-  transform:scaleY(var(--ach-cover,0));
+  transform:scaleY(var(--ach-progress,1));
   transition:transform 0.25s ease;
   z-index:0;
 }
@@ -748,16 +748,16 @@ input[type="checkbox"]{
 }
 
 .ach-icon::before{
-  background:rgba(255,255,255,0.65);
+  background:rgba(255,255,255,0.55);
   box-shadow:inset 0 0 0 1px rgba(255,255,255,0.6),0 4px 10px -6px rgba(15,23,42,0.4);
-  z-index:0;
+  z-index:1;
 }
 
 .ach-icon::after{
   background:var(--ach-bg,var(--surface-strong));
   transform-origin:bottom center;
-  transform:scaleY(var(--ach-cover,0));
-  z-index:1;
+  transform:scaleY(var(--ach-progress,1));
+  z-index:0;
 }
 
 .ach-icon-emoji{
@@ -804,9 +804,11 @@ body[data-theme="dark"] .ach-badge.is-partial .ach-icon::before{
 }
 
 .ach-badge:hover .ach-tooltip,
-.ach-badge:focus-visible .ach-tooltip{
+.ach-badge:focus-visible .ach-tooltip,
+.ach-badge.is-tooltip-active .ach-tooltip{
   opacity:1;
   transform:translate(calc(-50% + var(--ach-tooltip-shift, 0px)), 0);
+  pointer-events:auto;
 }
 
 #map{

--- a/js/ui-controls.js
+++ b/js/ui-controls.js
@@ -360,7 +360,9 @@ export function renderAchievements(metrics) {
     if (isPartial) cls.push('is-partial');
     return `
       <div class="${cls.join(' ')}" role="listitem"${style} tabindex="0" aria-label="${escapeAttr(aria)}">
-        <span class="ach-icon" aria-hidden="true">${achievement.emoji}</span>
+        <span class="ach-icon" aria-hidden="true">
+          <span class="ach-icon-emoji">${achievement.emoji}</span>
+        </span>
         ${tooltipHtml}
       </div>
     `;
@@ -423,11 +425,23 @@ function setupAchievementTooltips(root) {
       }
     };
 
-    badge.addEventListener('pointerenter', scheduleApply);
-    badge.addEventListener('focus', scheduleApply);
-    badge.addEventListener('pointerleave', resetShift);
-    badge.addEventListener('blur', resetShift);
-    badge.addEventListener('touchstart', scheduleApply, { passive: true });
+    const showTooltip = () => {
+      badge.classList.add('is-tooltip-active');
+      scheduleApply();
+    };
+
+    const hideTooltip = () => {
+      badge.classList.remove('is-tooltip-active');
+      resetShift();
+    };
+
+    badge.addEventListener('pointerenter', showTooltip);
+    badge.addEventListener('focus', showTooltip);
+    badge.addEventListener('pointerleave', hideTooltip);
+    badge.addEventListener('blur', hideTooltip);
+    badge.addEventListener('touchstart', showTooltip, { passive: true });
+    badge.addEventListener('touchend', hideTooltip, { passive: true });
+    badge.addEventListener('touchcancel', hideTooltip, { passive: true });
   });
 }
 


### PR DESCRIPTION
## Summary
- ensure achievement tooltips are activated via JS when badges gain hover, focus, or touch
- allow visible tooltips to receive pointer events so hover hints stay open

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbf40008d48331ab58d175f7923e15