### PR TITLE
Increase achievement icon image scale

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -773,6 +773,8 @@ input[type="checkbox"]{
   display:block;
   position:relative;
   z-index:2;
+  transform:scale(1.4);
+  transform-origin:center;
 }
 
 body[data-theme="dark"] .ach-icon::before{


### PR DESCRIPTION
## Summary
- further enlarge achievement badge icon images so they occupy even more of the circular frame while retaining badge dimensions

## Testing
- No tests (project has none)

------
https://chatgpt.com/codex/tasks/task_e_68dd7653b2d883319166eb5fdbff96b2