### PR TITLE
Fix achievements tooltip visibility

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -701,7 +701,7 @@ input[type="checkbox"]{
   box-shadow:0 12px 24px -16px rgba(17,24,39,0.4);
   transition:transform 0.2s ease, box-shadow 0.2s ease;
   outline:0;
-  overflow:hidden;
+  overflow:visible;
   z-index:0;
 }
 


### PR DESCRIPTION
## Summary
- allow achievement badges to overflow so tooltip comments remain visible on hover

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de328b19008331887c687cbd658c57