### PR TITLE
Stretch achievement art to badge edges

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -690,11 +690,11 @@ input[type="checkbox"]{
   --ach-cover:0;
   position:relative;
   display:flex;
-  align-items:center;
+  align-items:stretch;
   justify-content:center;
   width:48px;
-  height:48px;
-  border-radius:16px;
+  height:64px;
+  border-radius:999px;
   border:1px solid var(--ach-border,var(--surface-border));
   background:var(--surface-strong);
   color:var(--ach-text,var(--text));
@@ -725,9 +725,9 @@ input[type="checkbox"]{
 }
 
 .ach-icon{
-  width:32px;
-  height:32px;
-  border-radius:50%;
+  width:100%;
+  height:100%;
+  border-radius:inherit;
   display:flex;
   align-items:center;
   justify-content:center;
@@ -736,6 +736,8 @@ input[type="checkbox"]{
   z-index:1;
   overflow:hidden;
   color:inherit;
+  flex:1 1 100%;
+  align-self:stretch;
 }
 
 .ach-icon::before,
@@ -748,8 +750,8 @@ input[type="checkbox"]{
 }
 
 .ach-icon::before{
-  background:rgba(255,255,255,0.55);
-  box-shadow:inset 0 0 0 1px rgba(255,255,255,0.6),0 4px 10px -6px rgba(15,23,42,0.4);
+  background:transparent;
+  box-shadow:none;
   z-index:1;
 }
 
@@ -773,21 +775,20 @@ input[type="checkbox"]{
   display:block;
   position:relative;
   z-index:2;
-  transform:scale(1.4);
-  transform-origin:center;
+  transform:none;
 }
 
 body[data-theme="dark"] .ach-icon::before{
-  background:rgba(15,23,42,0.35);
-  box-shadow:inset 0 0 0 1px rgba(255,255,255,0.18),0 6px 12px -8px rgba(0,0,0,0.75);
+  background:transparent;
+  box-shadow:none;
 }
 
 .ach-badge.is-partial .ach-icon::before{
-  background:rgba(255,255,255,0.8);
+  background:transparent;
 }
 
 body[data-theme="dark"] .ach-badge.is-partial .ach-icon::before{
-  background:rgba(15,23,42,0.45);
+  background:transparent;
 }
 
 .ach-tooltip{


### PR DESCRIPTION
## Summary
- stretch the badge flex container so the icon fills the vertical oval
- allow the achievement image to flex to the badge bounds to remove the inner gap

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de38e61a0c83318cceca577293d886