### PR TITLE
Update achievement badge styling for transparent icons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -695,10 +695,10 @@ input[type="checkbox"]{
   width:48px;
   height:64px;
   border-radius:999px;
-  border:1px solid var(--ach-border,var(--surface-border));
-  background:var(--surface-strong);
+  border:none;
+  background:transparent;
   color:var(--ach-text,var(--text));
-  box-shadow:0 12px 24px -16px rgba(17,24,39,0.4);
+  box-shadow:none;
   transition:transform 0.2s ease, box-shadow 0.2s ease;
   outline:0;
   overflow:visible;
@@ -708,20 +708,13 @@ input[type="checkbox"]{
 .ach-badge:hover,
 .ach-badge:focus-visible{
   transform:translateY(-2px);
-  box-shadow:0 24px 38px -26px rgba(17,24,39,0.45);
+  box-shadow:none;
   z-index:20;
 }
 
 .ach-badge::before{
-  content:"";
-  position:absolute;
-  inset:0;
-  border-radius:inherit;
-  background:var(--ach-bg,var(--surface-strong));
-  transform-origin:bottom center;
-  transform:scaleY(var(--ach-progress,1));
-  transition:transform 0.25s ease;
-  z-index:0;
+  content:none;
+  display:none;
 }
 
 .ach-icon{
@@ -756,10 +749,8 @@ input[type="checkbox"]{
 }
 
 .ach-icon::after{
-  background:var(--ach-bg,var(--surface-strong));
-  transform-origin:bottom center;
-  transform:scaleY(var(--ach-progress,1));
-  z-index:0;
+  content:none;
+  display:none;
 }
 
 .ach-icon-emoji{


### PR DESCRIPTION
## Summary
- remove the default background, border, and box shadow from achievement badges
- disable badge pseudo-elements so PNG icons remain unobstructed in both themes

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dea07f83dc83318641107d6f83314e