### PR TITLE
Hide duplicate filters heading text

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
           </summary>
           <div class="overlay-body" role="region" aria-labelledby="filtersHeading">
             <div class="overlay-heading-row">
-              <h2 class="overlay-heading" id="filtersHeading">Фильтры и слои</h2>
+              <h2 class="overlay-heading sr-only" id="filtersHeading">Фильтры и слои</h2>
               <button class="overlay-info-toggle" type="button" aria-expanded="false" aria-controls="filtersInfoText" data-overlay-info-toggle>
                 <span aria-hidden="true">ℹ️</span>
                 <span class="sr-only">Показать описание фильтров</span>


### PR DESCRIPTION
## Summary
- hide the redundant "Фильтры и слои" heading in the overlay body while keeping it for accessibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e16a4f23388331928f294780ddb5c5