### PR TITLE
Enable route and country highlights on load

### DIFF
--- a/js/map-init.js
+++ b/js/map-init.js
@@ -136,6 +136,7 @@ export function createMapController({ accessToken, theme, flagMode }) {
     layersInitialized: false,
     interactionsBound: false,
     routesVisible: false,
+    countriesVisible: false,
   };
 
   const withMapReady = (fn) => {
@@ -243,7 +244,8 @@ export function createMapController({ accessToken, theme, flagMode }) {
   };
 
   const setCountriesVisibility = (stateVisible) => {
-    const vis = stateVisible ? 'visible' : 'none';
+    state.countriesVisible = Boolean(stateVisible);
+    const vis = state.countriesVisible ? 'visible' : 'none';
     if (map.getLayer('countries-visited-fill')) map.setLayoutProperty('countries-visited-fill', 'visibility', vis);
     if (map.getLayer('countries-visited-outline')) map.setLayoutProperty('countries-visited-outline', 'visibility', vis);
   };
@@ -378,8 +380,8 @@ export function createMapController({ accessToken, theme, flagMode }) {
     }
 
     ensureCountriesLayers();
-    setCountriesVisibility(false);
-    setRoutesVisibility(false);
+    setCountriesVisibility(state.countriesVisible);
+    setRoutesVisibility(state.routesVisible);
 
     bindInteractions();
     state.layersInitialized = true;

--- a/js/ui-controls.js
+++ b/js/ui-controls.js
@@ -610,6 +610,7 @@ export function createUIController({
   onRoutesToggle,
   onVisitedToggle,
   onProcessChange,
+  initialToggles,
 }) {
   const root = buildControlsHTML(pointsCount, countriesCount, filterState.process);
   const routesToggle = root.querySelector('#toggleRoutes');
@@ -619,15 +620,20 @@ export function createUIController({
   const filtersInfoToggle = filtersMenu?.querySelector('[data-overlay-info-toggle]');
   const filtersInfoPanel = filtersMenu?.querySelector('[data-overlay-info-panel]');
 
+  const routesInitial = typeof initialToggles?.routes === 'boolean' ? initialToggles.routes : true;
+  const visitedInitial = typeof initialToggles?.visited === 'boolean' ? initialToggles.visited : true;
+
   setupInfoDisclosure({
     toggle: filtersInfoToggle,
     panel: filtersInfoPanel,
   });
 
   if (routesToggle) {
+    routesToggle.checked = routesInitial;
     routesToggle.addEventListener('change', (e) => onRoutesToggle?.(e.target.checked), { passive: true });
   }
   if (visitedToggle) {
+    visitedToggle.checked = visitedInitial;
     visitedToggle.addEventListener('change', (e) => onVisitedToggle?.(e.target.checked), { passive: true });
   }
   processButtons.forEach((btn) => {
@@ -636,6 +642,9 @@ export function createUIController({
       onProcessChange?.(raw);
     }, { passive: true });
   });
+
+  onRoutesToggle?.(routesInitial);
+  onVisitedToggle?.(visitedInitial);
 
   const updateCounts = (points, countries) => {
     const pointsEl = root.querySelector('#pointsCount');


### PR DESCRIPTION
## Summary
- remember the visibility state for visited countries in the map controller
- default the UI toggles to enabled so routes and visited countries are shown immediately

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e16a742434833196e9e6f82e2a373e