### PR TITLE
Add hint icon next to countries counter

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -670,6 +670,34 @@ body[data-theme="dark"] .filter-chip.is-active .filter-dot{
   font-weight:500;
 }
 
+.chip-hint{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  padding:0;
+  width:18px;
+  height:18px;
+  border-radius:50%;
+  border:0;
+  background:var(--accent-soft);
+  color:var(--accent);
+  font-size:12px;
+  line-height:1;
+  flex-shrink:0;
+  cursor:help;
+  transition:background-color 0.2s ease,color 0.2s ease;
+}
+
+.chip-hint:hover,
+.chip-hint:focus-visible{
+  background:var(--accent);
+  color:#fff;
+}
+
+.chip-hint:focus:not(:focus-visible){
+  outline:none;
+}
+
 label{
   display:inline-flex;
   align-items:center;

--- a/js/ui-controls.js
+++ b/js/ui-controls.js
@@ -576,7 +576,7 @@ function buildControlsHTML(pointsCount, countriesCount, activeProcess = 'all') {
   wrap.innerHTML = `
     <div class="filters-stats">
       <span class="chip" title="Точек на карте">☕ <span id="pointsCount">${pointsCount}</span></span>
-      <span class="chip" title="Стран в коллекции">🌍 <span id="countriesCount">${countriesCount}</span></span>
+      <span class="chip" title="Стран в коллекции">🌍 <span id="countriesCount">${countriesCount}</span><button type="button" class="chip-hint" title="Количество уникальных стран в коллекции" aria-label="Количество уникальных стран в коллекции">ℹ️</button></span>
     </div>
     <div class="filters-section">
       <span class="filters-label">Отображение</span>


### PR DESCRIPTION
## Summary
- add an inline hint button beside the countries statistic chip
- style the hint control to match the overlay accent appearance

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2aa07b1c08331bdce145c2840ffb8