### PR TITLE
Align filters stats hint button with counter chips

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -504,6 +504,17 @@ body[data-theme="dark"] .brand-tag{
   align-items:center;
 }
 
+.filters-stats-counts{
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+  align-items:center;
+}
+
+.filters-stats-hint{
+  margin-left:auto;
+}
+
 .filters-section{
   display:flex;
   flex-direction:column;

--- a/js/ui-controls.js
+++ b/js/ui-controls.js
@@ -575,8 +575,11 @@ function buildControlsHTML(pointsCount, countriesCount, activeProcess = 'all') {
   }).join('');
   wrap.innerHTML = `
     <div class="filters-stats">
-      <span class="chip" title="Точек на карте">☕ <span id="pointsCount">${pointsCount}</span></span>
-      <span class="chip" title="Стран в коллекции">🌍 <span id="countriesCount">${countriesCount}</span><button type="button" class="chip-hint" title="Количество уникальных стран в коллекции" aria-label="Количество уникальных стран в коллекции">ℹ️</button></span>
+      <div class="filters-stats-counts">
+        <span class="chip" title="Точек на карте">☕ <span id="pointsCount">${pointsCount}</span></span>
+        <span class="chip" title="Стран в коллекции">🌍 <span id="countriesCount">${countriesCount}</span></span>
+      </div>
+      <button type="button" class="chip-hint filters-stats-hint" title="Количество уникальных стран в коллекции" aria-label="Количество уникальных стран в коллекции">ℹ️</button>
     </div>
     <div class="filters-section">
       <span class="filters-label">Отображение</span>


### PR DESCRIPTION
## Summary
- reposition the statistics hint button to share the same row as the coffee and country counters
- adjust the filters stats layout styles to keep the counters grouped and align the hint button

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e3da7e0c8c8331b8d16e9e491d12e5