### PR TITLE
Показывать на странице статистики только открытые достижения и 2 последних закрытых

### DIFF
--- a/js/ui-controls.js
+++ b/js/ui-controls.js
@@ -710,11 +710,47 @@ export function renderAchievements(metrics, options = {}) {
 
   const lookup = new Map(evaluated.map((achievement) => [achievement.id, achievement]));
 
-  const selectionMode = String(globalScope?.document?.body?.dataset?.achievementsSelection || '').toLowerCase();
+  const requestedSelectionMode = String(options?.selectionMode || '').toLowerCase();
+  const selectionMode = requestedSelectionMode
+    || String(globalScope?.document?.body?.dataset?.achievementsSelection || '').toLowerCase();
+
+  const resolveAchievementClosedAt = (achievement) => {
+    const id = achievement?.id;
+    if (!id || !metrics || typeof metrics !== 'object') return null;
+
+    const candidates = [
+      metrics?.achievementClosedAt?.[id],
+      metrics?.achievementsClosedAt?.[id],
+      metrics?.achievementCompletedAt?.[id],
+      metrics?.achievementsCompletedAt?.[id],
+      metrics?.achievementTimeline?.[id]?.closedAt,
+      metrics?.achievementTimeline?.[id]?.completedAt,
+      metrics?.achievementsTimeline?.[id]?.closedAt,
+      metrics?.achievementsTimeline?.[id]?.completedAt,
+    ];
+
+    for (const candidate of candidates) {
+      if (candidate === undefined || candidate === null || candidate === '') continue;
+      const timestamp = Number(new Date(candidate));
+      if (Number.isFinite(timestamp) && timestamp > 0) return timestamp;
+    }
+
+    return null;
+  };
+
   const selectRecentOpen = () => {
     const closed = evaluated.filter((achievement) => achievement.earned);
     const latestClosed = closed
-      .sort((a, b) => b.originalIndex - a.originalIndex)
+      .sort((a, b) => {
+        const timeA = resolveAchievementClosedAt(a);
+        const timeB = resolveAchievementClosedAt(b);
+        if (timeA !== null || timeB !== null) {
+          if (timeA === null) return 1;
+          if (timeB === null) return -1;
+          if (timeA !== timeB) return timeB - timeA;
+        }
+        return b.originalIndex - a.originalIndex;
+      })
       .slice(0, 2);
     const opened = evaluated.filter((achievement) => !achievement.earned);
     return [...latestClosed, ...opened];


### PR DESCRIPTION
### Motivation
- На странице статистики нужно показывать только открытые достижения и дополнительно 2 последних закрытых по времени, вместо предыдущего порядка по индексу. 
- Также требуется, чтобы вызов `renderAchievements` мог явно задавать режим выбора через опцию `selectionMode`, что необходимо для страницы статистики.

### Description
- Изменён `renderAchievements` в `js/ui-controls.js`, теперь он сначала учитывает `options.selectionMode` перед чтением `body.dataset.achievementsSelection` (поддержка `recent-open`).
- Добавлена функция `resolveAchievementClosedAt` которая извлекает время закрытия/выполнения из возможных полей в `metrics` (несколько вариантов ключей и timeline-полей) и возвращает timestamp.
- Сортировка закрытых достижений обновлена: сначала по найденным timestamp (по убыванию — последние первыми), с детерминированным fallback на `originalIndex` если timestamps недоступны, и затем берутся верхние 2 элемента.

### Testing
- Выполнена статическая проверка синтаксиса `node --check js/ui-controls.js`, которая прошла успешно.
- Запуск `npm run test:prebuilt` был попытан в CI, но все тесты завершились ошибкой из-за отсутствия скачанных браузерных бинарников Playwright (ошибка запуска Chromium headless), поэтому интеграционные тесты не прошли в этой среде. 
- Изменение закоммичено (см. изменения в `js/ui-controls.js`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d51190f5bc8331850091ccb45591bd)