### PR TITLE
Remove uploader from popup card and compact fields into two columns

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1021,6 +1021,32 @@ body[data-theme="dark"] .map-error{
   color:var(--text);
 }
 
+.popup-fields{
+  display:grid;
+  grid-template-columns:repeat(2,minmax(0,1fr));
+  column-gap:10px;
+  row-gap:2px;
+}
+
+.popup-field{
+  margin:2px 0;
+  display:flex;
+  align-items:flex-start;
+  gap:8px;
+  min-width:0;
+  color:var(--text);
+}
+
+.popup-field span:last-child{
+  min-width:0;
+  word-break:break-word;
+}
+
+.popup-subtext{
+  color:var(--muted);
+  font-size:var(--text-xs);
+}
+
 .row-emoji{
   width:1.4em;
   text-align:center;

--- a/js/map-init.js
+++ b/js/map-init.js
@@ -221,13 +221,14 @@ function popupHTML(p, flagMode) {
     if (p.consumedCity) bits.push(escapeHtml(p.consumedCity));
     let whereHtml = bits.join(' — ');
     if (p.cafeUrl) whereHtml += ` <a href="${escapeAttr(p.cafeUrl)}" target="_blank" rel="noopener" title="Ссылка на заведение">🔗</a>`;
+    if (p.consumedAddr) {
+      whereHtml += `<br><span class="popup-subtext">${escapeHtml(p.consumedAddr)}</span>`;
+    }
     rows.push(emojiRow('📍', 'Where', whereHtml));
-    if (p.consumedAddr) rows.push(`<div class="row" style="margin-left:1.6em;color:#666">${escapeHtml(p.consumedAddr)}</div>`);
   }
 
   if (p.recipe) rows.push(emojiRow('📋', 'Recipe', escapeHtml(p.recipe)));
   if (roaster) rows.push(emojiRow('🏭', 'Roaster', roaster));
-  if (p.uploader) rows.push(emojiRow('👤', 'By', escapeHtml(p.uploader)));
 
   const processType = p.process_norm || 'other';
   const colors = processColors(processType);
@@ -242,13 +243,13 @@ function popupHTML(p, flagMode) {
       <div class="popup-body">
         <div class="popup-title">${escapeHtml(p.farmName || 'Без названия')}</div>
         <div class="meta">${place || '—'}</div>
-        ${rows.join('')}
+        <div class="popup-fields">${rows.join('')}</div>
       </div>
     </div>
   `;
 
   function emojiRow(emoji, title, val) {
-    return `<div class="row"><span class="row-emoji" title="${escapeAttr(title)}">${emoji}</span><span>${val || ''}</span></div>`;
+    return `<div class="popup-field"><span class="row-emoji" title="${escapeAttr(title)}">${emoji}</span><span>${val || ''}</span></div>`;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Make the point popup card more compact and focused by removing the uploader line and tightening field layout.
- Reduce visual clutter on small popups by merging the consumed address into the location field as muted subtext.

### Description
- Stop rendering the uploader row in the popup by removing the `p.uploader` check in `popupHTML` (`js/map-init.js`).
- Wrap existing popup rows into a two-column grid container `.popup-fields` and switch per-row markup from `.row` to `.popup-field` (`js/map-init.js`).
- Move `consumedAddr` into the location field as `<span class="popup-subtext">` and render it inline with the location/link (`js/map-init.js`).
- Add CSS rules to support the compact two-column layout and muted subtext: `.popup-fields`, `.popup-field`, `.popup-subtext` (`css/style.css`).

### Testing
- Ran `npm run check:dataset`, which failed because `data/dataset.json` is missing in this environment.  (expected failure in CI-free environment)
- Ran `npm run build:dataset`, which failed with network error `ENETUNREACH` when fetching the Google Sheets CSV source.  (failure unrelated to UI changes)
- No UI unit tests were modified; visual verification recommended in a browser after building the site dataset.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7ad42e7448331bdbfeedc58fb1ed0)