### PR TITLE
Показывать обжарщика в попапе и корректно отображать «Где выпито»

### DIFF
--- a/js/map-init.js
+++ b/js/map-init.js
@@ -215,10 +215,18 @@ function popupHTML(p, flagMode) {
   const rows = [];
   if (p.brewMethod) rows.push(emojiRow('🧉', 'Method', escapeHtml(p.brewMethod)));
 
-  if (p.whereConsumed || p.consumedCity || p.consumedAddr || p.cafeUrl) {
+  if (p.whereConsumed || p.cafeName || p.consumedAddr || p.cafeUrl) {
     const bits = [];
-    if (p.whereConsumed) bits.push(escapeHtml(p.whereConsumed));
-    if (p.consumedCity) bits.push(escapeHtml(p.consumedCity));
+    const whereConsumed = String(p.whereConsumed || '').trim();
+    const cafeName = String(p.cafeName || '').trim();
+    const isCoffeeShop = /^coffeeshop$/i.test(whereConsumed);
+    if (isCoffeeShop && cafeName) {
+      bits.push(escapeHtml(cafeName));
+    } else if (whereConsumed) {
+      bits.push(escapeHtml(whereConsumed));
+    } else if (cafeName) {
+      bits.push(escapeHtml(cafeName));
+    }
     let whereHtml = bits.join(' — ');
     if (p.cafeUrl) whereHtml += ` <a href="${escapeAttr(p.cafeUrl)}" target="_blank" rel="noopener" title="Ссылка на заведение">🔗</a>`;
     if (p.consumedAddr) {
@@ -241,7 +249,7 @@ function popupHTML(p, flagMode) {
       ${badge}
       ${photo}
       <div class="popup-body">
-        <div class="popup-title">${escapeHtml(p.farmName || 'Без названия')}</div>
+        <div class="popup-title">${escapeHtml(p.roasterName || 'Без названия')}</div>
         <div class="meta">${place || '—'}</div>
         <div class="popup-fields">${rows.join('')}</div>
       </div>


### PR DESCRIPTION
### Motivation
- Попап-карточка должна показывать обжарщика вместо названия фермы для более релевантного заголовка записи. 
- В строке «Где выпито» не должно автоматически выводиться название города, нужно показывать только тип/название места, ссылку и адрес. 
- Если `whereConsumed` равен `Coffeeshop`, предпочтительно показывать фактическое название кофейни (`cafeName`), а не слово «Coffeeshop». 

### Description
- В `js/map-init.js` изменён заголовок попапа: теперь используется `roasterName` вместо `farmName` для вывода в `.popup-title`.
- В той же функции `popupHTML` переработана логика формирования строки «Where»: добавлены приведение к строке и `trim`, логика определения `isCoffeeShop` через `/^coffeeshop$/i`, и вывод `cafeName` когда применимо, при этом больше не добавляется `consumedCity` в эту строку.
- Изменения касаются только `js/map-init.js` и не затрагивают остальные части приложения.

### Testing
- Выполнена синтаксическая проверка файла командой `node --check js/map-init.js`, которая завершилась успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8d3fc8e8c8331bd14231dd0621b2c)