### PR TITLE
Adjust country dropdown width and flag sizing

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -325,6 +325,9 @@ body[data-theme="dark"] .map-loading{
   position:absolute;
   top:calc(100% + 10px);
   left:0;
+  min-width:200px;
+  width:max-content;
+  max-width:min(280px,calc(100vw - 32px));
   max-height:320px;
   overflow:auto;
   padding:10px;
@@ -350,11 +353,13 @@ body[data-theme="dark"] .map-loading{
   gap:10px;
   font-size:var(--text-sm);
   color:var(--text);
+  white-space:nowrap;
 }
 
 .map-stat-dropdown-flag{
-  width:28px;
-  height:20px;
+  width:26px;
+  height:18px;
+  flex:0 0 26px;
   border-radius:4px;
   overflow:hidden;
   display:inline-flex;


### PR DESCRIPTION
### Motivation
- Prevent country names in the stats dropdown from wrapping and ensure flags align neatly in the list.
- Avoid the dropdown overflowing the viewport on small screens while allowing longer country names to be visible.

### Description
- Updated `css/style.css` to add `min-width: 200px`, `width: max-content`, and `max-width: min(280px, calc(100vw - 32px))` to `.map-stat-dropdown` to reduce wrapping and constrain overflow.
- Added `white-space: nowrap` to `.map-stat-dropdown-item` to keep country names on a single line.
- Adjusted `.map-stat-dropdown-flag` dimensions to `width: 26px`, `height: 18px`, and `flex: 0 0 26px` so flags line up consistently.

### Testing
- No automated tests were run because this is a CSS-only visual adjustment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8d467d0548331aabbe912ec41f9a4)