### PR TITLE
Перенести доступ к достижениям на страницу статистики

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -704,6 +704,12 @@ body[data-theme="dark"] .map-loading{
   min-height:92px;
 }
 
+.stats-achievements-actions{
+  margin-top:12px;
+  display:flex;
+  justify-content:flex-start;
+}
+
 @media (max-width:900px){
   .stats-kpis{
     grid-template-columns:repeat(2,minmax(0,1fr));

--- a/index.html
+++ b/index.html
@@ -45,24 +45,6 @@
         <p class="map-subtitle" id="mapInfoText" data-map-info-panel hidden>Передвигайте карту и кликайте на маркеры, чтобы увидеть путь зерна от фермы до чашки.</p>
       </header>
 
-      <div class="map-achievements" data-achievements-root hidden>
-        <button
-          class="achievements-toggle"
-          type="button"
-          aria-expanded="false"
-          aria-controls="achievementsPanel"
-          data-achievements-toggle
-          data-label-collapsed="Показать достижения"
-          data-label-expanded="Скрыть достижения"
-        >
-          Показать достижения
-        </button>
-        <div class="achievements-panel" id="achievementsPanel" data-achievements-panel hidden>
-          <span class="sr-only" id="achievementsLabel">Достижения</span>
-          <div class="achievements" id="achievements" role="list" aria-labelledby="achievementsLabel"></div>
-        </div>
-      </div>
-
       <a class="map-secondary-link" href="stats.html">Открыть статистику</a>
 
     </div>

--- a/js/stats.js
+++ b/js/stats.js
@@ -5,9 +5,23 @@ const DEFAULT_MAPBOX_TOKEN = 'pk.eyJ1IjoibWF4MTQwNTE5OTMtY29mZmVlIiwiYSI6ImNtZTV
 const DEFAULT_GOOGLE_SHEET_ID = '1D87usuWeFvUv9ejZ5igywlncq604b5hoRLFkZ9cjigw';
 const DEFAULT_GOOGLE_SHEET_GID = '0';
 const DEFAULT_PREBUILT_DATASET_URL = '';
+const showAllAchievementsButton = document.querySelector('[data-show-all-achievements]');
+let currentMetrics = null;
 
 const urlParams = new URLSearchParams(window.location.search);
 document.body.dataset.achievementsView = 'compact';
+document.body.dataset.achievementsSelection = 'recent-open';
+
+function renderStatsAchievements(showAll = false) {
+  if (!currentMetrics) return;
+  renderAchievements(currentMetrics, {
+    viewMode: 'detailed',
+    selectionMode: showAll ? 'all' : 'recent-open',
+  });
+  if (showAllAchievementsButton) {
+    showAllAchievementsButton.hidden = showAll;
+  }
+}
 
 function resolveMapboxToken(params) {
   const explicitToken = params.get('mapboxToken')
@@ -59,6 +73,7 @@ function setText(selector, value) {
 
 function renderKpis(dataset) {
   const metrics = dataset?.metrics || {};
+  currentMetrics = metrics;
   const total = Number(metrics.total || 0);
   const countriesTotal = Number.isFinite(metrics?.countries)
     ? Number(metrics.countries)
@@ -71,14 +86,16 @@ function renderKpis(dataset) {
   setText('[data-kpi-countries-total]', String(countriesTotal));
   setText('[data-kpi-roaster-countries]', String(roasterCountriesTotal));
 
-  renderAchievements(metrics, {
-    viewMode: 'detailed',
-    selectionMode: 'recent-open',
-  });
-
+  renderStatsAchievements(false);
 }
 
 async function initStatsPage() {
+  if (showAllAchievementsButton) {
+    showAllAchievementsButton.addEventListener('click', () => {
+      renderStatsAchievements(true);
+    });
+  }
+
   const statusEl = document.querySelector('[data-stats-status]');
   if (statusEl) statusEl.textContent = 'Загружаем актуальную статистику…';
 

--- a/stats.html
+++ b/stats.html
@@ -46,6 +46,11 @@
           </div>
           <p class="stats-status" data-stats-status role="status" aria-live="polite"></p>
           <div class="stats-achievements-grid achievements" id="achievements" role="list" aria-label="Список очивок"></div>
+          <div class="stats-achievements-actions">
+            <button class="achievements-toggle" type="button" data-show-all-achievements>
+              Показать все достижения
+            </button>
+          </div>
         </article>
       </section>
     </div>


### PR DESCRIPTION
### Motivation
- Упростить главный экран: убрать интерактивный блок достижений с `index.html` и оставить только ссылку на статистику.
- Позволить просматривать полный список достижений на отдельной странице статистики (`stats.html`).

### Description
- Удалён блок достижений из `index.html`, оставлена только ссылка на `stats.html`.
- В `stats.html` добавлена кнопка `Показать все достижения` внизу сетки достижений (`data-show-all-achievements`).
- В `js/stats.js` добавлены переменные и `renderStatsAchievements()` для начального рендера в режиме `recent-open` и переключения на показ всех достижений по нажатию кнопки, а также сохранение `currentMetrics` для повторного рендера.
- В `css/style.css` добавлен стиль для контейнера кнопки (`.stats-achievements-actions`) для корректного отступа и выравнивания.

### Testing
- Выполнена проверка синтаксиса: `node --check js/stats.js && node --check js/app.js` — успешно.
- Выполнен `npm run check:dataset` — завершился с ошибкой в окружении из‑за отсутствия `data/dataset.json`, ошибка не связана с изменениями в коде.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8d541e498833193fc60963b1b4ea1)