### PR TITLE
Prevent overlapping map stats dropdowns

### DIFF
--- a/js/ui-controls.js
+++ b/js/ui-controls.js
@@ -198,6 +198,18 @@ const renderCountryList = (countries) => {
 const setupCountryDropdown = (button, dropdown, root) => {
   if (!button || !dropdown || dropdown.dataset.bound === 'true') return;
 
+  const closeSiblings = () => {
+    const scope = root?.closest?.('[data-stats]') || document;
+    const allDropdowns = scope.querySelectorAll?.('.map-stat-dropdown');
+    const allButtons = scope.querySelectorAll?.('.map-stat-value-button[aria-expanded="true"]');
+    allDropdowns?.forEach((el) => {
+      if (el !== dropdown) el.hidden = true;
+    });
+    allButtons?.forEach((el) => {
+      if (el !== button) el.setAttribute('aria-expanded', 'false');
+    });
+  };
+
   const close = () => {
     dropdown.hidden = true;
     button.setAttribute('aria-expanded', 'false');
@@ -205,6 +217,7 @@ const setupCountryDropdown = (button, dropdown, root) => {
 
   const open = () => {
     if (!dropdown.children.length) return;
+    closeSiblings();
     positionDropdownBelowButton(dropdown, button);
     dropdown.hidden = false;
     button.setAttribute('aria-expanded', 'true');


### PR DESCRIPTION
### Motivation
- При открытии нескольких дропдаунов в блоке статистики они наслаивались друг на друга, поэтому нужно автоматически закрывать соседние меню и синхронизировать состояние кнопок для корректного UX и доступности.

### Description
- Добавлен вспомогательный `closeSiblings()` в `setupCountryDropdown` (файл `js/ui-controls.js`), который закрывает все другие элементы с классом `.map-stat-dropdown` внутри панели `[data-stats]` и сбрасывает `aria-expanded` у других кнопок перед открытием текущего дропдауна, при этом существующее позиционирование и логика переключения сохранены.

### Testing
- Запуск автоматических тестов (`npm run test:prebuilt`) и попытка установки браузеров (`npx playwright install chromium`) были выполнены, но браузерные тесты не прошли в этом окружении из‑за отсутствия системных библиотек для Playwright (бинарники были загружены, но хост требует дополнительные зависимости), поэтому изменения не проверены проходящими в CI тестами.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8d5b127c48331bc669636a95fe07a)