### PR TITLE
Clamp stats dropdown horizontal position to prevent viewport overflow on mobile

### DIFF
--- a/js/ui-controls.js
+++ b/js/ui-controls.js
@@ -143,13 +143,24 @@ const positionDropdownBelowButton = (dropdown, button) => {
   if (!parent) return;
 
   const GAP = 10;
+  const VIEWPORT_MARGIN = 8;
   const buttonRect = button.getBoundingClientRect();
   const parentRect = parent.getBoundingClientRect();
+  const viewportWidth = globalScope?.document?.documentElement?.clientWidth || globalScope?.innerWidth || 0;
+  const dropdownStyle = globalScope.getComputedStyle ? getComputedStyle(dropdown) : null;
+  const measuredWidth = dropdown.offsetWidth
+    || parseSize(dropdownStyle?.width)
+    || parseSize(dropdown.style.width);
 
-  const left = buttonRect.left - parentRect.left;
+  const initialLeft = buttonRect.left - parentRect.left;
   const top = (buttonRect.top - parentRect.top) + button.offsetHeight + GAP;
+  const minLeft = VIEWPORT_MARGIN - parentRect.left;
+  const maxLeft = viewportWidth
+    ? viewportWidth - VIEWPORT_MARGIN - parentRect.left - measuredWidth
+    : initialLeft;
+  const clampedLeft = Math.min(Math.max(initialLeft, minLeft), Math.max(minLeft, maxLeft));
 
-  dropdown.style.left = `${left}px`;
+  dropdown.style.left = `${clampedLeft}px`;
   dropdown.style.top = `${top}px`;
 };
 


### PR DESCRIPTION
### Motivation
- Prevent the page from horizontally stretching when a stats/country dropdown is opened near the right edge of the viewport on small screens.
- Ensure dropdowns stay visible inside the viewport while preserving existing vertical placement behavior.

### Description
- Update `positionDropdownBelowButton` in `js/ui-controls.js` to compute `viewportWidth` and the dropdown `measuredWidth` before positioning. 
- Introduce a `VIEWPORT_MARGIN` and clamp the computed `left` value between a minimum and maximum allowed position so the dropdown cannot overflow the viewport. 
- Keep the existing vertical offset logic and only adjust horizontal placement using the measured width and parent offsets.

### Testing
- Ran `node --check js/ui-controls.js` which completed successfully. 
- Ran `npm run test:prebuilt` but Playwright tests failed to start in this environment due to missing Chromium binaries (error: instructs to run `npx playwright install`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8d7ed01b08331b5a9dfd37c280cb3)