### PR TITLE
Remove location icon from popup "Where consumed" row

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1048,6 +1048,10 @@ body[data-theme="dark"] .map-error{
   color:var(--text);
 }
 
+.popup-field--no-icon{
+  gap:0;
+}
+
 .popup-field span:last-child{
   min-width:0;
   word-break:break-word;

--- a/js/map-init.js
+++ b/js/map-init.js
@@ -230,7 +230,7 @@ function popupHTML(p, flagMode) {
     if (p.consumedAddr) {
       whereHtml += `<br><span class="popup-subtext">${escapeHtml(p.consumedAddr)}</span>`;
     }
-    rows.push(emojiRow('📍', 'Where', whereHtml));
+    rows.push(emojiRow('', 'Where', whereHtml));
   }
 
   if (p.recipe) rows.push(emojiRow('📋', 'Recipe', escapeHtml(p.recipe)));
@@ -254,7 +254,8 @@ function popupHTML(p, flagMode) {
   `;
 
   function emojiRow(emoji, title, val) {
-    return `<div class="popup-field"><span class="row-emoji" title="${escapeAttr(title)}">${emoji}</span><span>${val || ''}</span></div>`;
+    const hasEmoji = Boolean(String(emoji || '').trim());
+    return `<div class="popup-field${hasEmoji ? '' : ' popup-field--no-icon'}">${hasEmoji ? `<span class="row-emoji" title="${escapeAttr(title)}">${emoji}</span>` : ''}<span>${val || ''}</span></div>`;
   }
 }
 


### PR DESCRIPTION
### Motivation
- The popup row that shows where a coffee was consumed contained a location pin emoji and left a gap even when no icon was desired, so the UI needed the icon removed and the text shifted left.

### Description
- Removed the `📍` emoji for the "Where" row in `popupHTML` by passing an empty emoji to that row in `js/map-init.js`.
- Updated the `emojiRow` renderer in `js/map-init.js` to conditionally render the emoji cell and add a `popup-field--no-icon` modifier when no emoji is present.
- Added a CSS rule `.popup-field--no-icon { gap: 0; }` in `css/style.css` to remove the icon gap and shift the content left.

### Testing
- Ran `npm run check:dataset`, which failed in this environment due to a missing `data/dataset.json` and therefore could not complete; no other automated tests were run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8dba4d5908331af96c08368351eba)