### PR TITLE
Make country dropdown open as seamless panel without scrollbar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -323,17 +323,18 @@ body[data-theme="dark"] .map-loading{
 
 .map-stat-dropdown{
   position:absolute;
-  top:calc(100% + 10px);
+  top:calc(100% - 1px);
   left:0;
   min-width:200px;
   width:max-content;
   max-width:min(280px,calc(100vw - 32px));
-  max-height:320px;
-  overflow:auto;
+  max-height:none;
+  overflow:visible;
   padding:10px;
-  border-radius:12px;
+  border-radius:0 0 12px 12px;
   background:var(--surface-strong);
   border:1px solid var(--surface-border);
+  border-top:0;
   box-shadow:0 12px 24px -14px rgba(17,24,39,0.4);
   z-index:10;
 }

--- a/js/ui-controls.js
+++ b/js/ui-controls.js
@@ -130,21 +130,28 @@ const calculateDropdownWidth = (dropdown) => {
   return Math.ceil(longestName + gap + flagWidth + padding + border);
 };
 
-const setDropdownWidth = (dropdown) => {
+const setDropdownWidth = (dropdown, anchorContainer) => {
   const width = calculateDropdownWidth(dropdown);
   if (Number.isFinite(width) && width > 0) {
-    dropdown.style.width = `${width}px`;
+    const anchorWidth = anchorContainer?.offsetWidth || 0;
+    const targetWidth = Math.max(width, anchorWidth);
+    dropdown.style.width = `${targetWidth}px`;
+    if (anchorContainer && targetWidth > anchorWidth) {
+      anchorContainer.style.width = `${targetWidth}px`;
+    }
   }
 };
 
-const positionDropdownBelowButton = (dropdown, button) => {
+const positionDropdownBelowButton = (dropdown, button, root) => {
   if (!dropdown || !button) return;
   const parent = dropdown.offsetParent;
   if (!parent) return;
 
-  const GAP = 10;
+  const GAP = -1;
   const VIEWPORT_MARGIN = 8;
+  const statsContainer = root?.closest?.('[data-stats]');
   const buttonRect = button.getBoundingClientRect();
+  const statsRect = statsContainer?.getBoundingClientRect();
   const parentRect = parent.getBoundingClientRect();
   const viewportWidth = globalScope?.document?.documentElement?.clientWidth || globalScope?.innerWidth || 0;
   const dropdownStyle = globalScope.getComputedStyle ? getComputedStyle(dropdown) : null;
@@ -152,8 +159,8 @@ const positionDropdownBelowButton = (dropdown, button) => {
     || parseSize(dropdownStyle?.width)
     || parseSize(dropdown.style.width);
 
-  const initialLeft = buttonRect.left - parentRect.left;
-  const top = (buttonRect.top - parentRect.top) + button.offsetHeight + GAP;
+  const initialLeft = (statsRect ? statsRect.left : buttonRect.left) - parentRect.left;
+  const top = ((statsRect ? statsRect.bottom : (buttonRect.top + button.offsetHeight)) - parentRect.top) + GAP;
   const minLeft = VIEWPORT_MARGIN - parentRect.left;
   const maxLeft = viewportWidth
     ? viewportWidth - VIEWPORT_MARGIN - parentRect.left - measuredWidth
@@ -229,7 +236,7 @@ const setupCountryDropdown = (button, dropdown, root) => {
   const open = () => {
     if (!dropdown.children.length) return;
     closeSiblings();
-    positionDropdownBelowButton(dropdown, button);
+    positionDropdownBelowButton(dropdown, button, root);
     dropdown.hidden = false;
     button.setAttribute('aria-expanded', 'true');
   };
@@ -318,7 +325,7 @@ export function renderStats(metrics) {
   if (countryDropdown && countryList) {
     if (visitedCountries.length) {
       countryList.innerHTML = renderCountryList(visitedCountries);
-      setDropdownWidth(countryDropdown);
+      setDropdownWidth(countryDropdown, container);
       countryDropdown.hidden = true;
       if ('disabled' in countriesEl) countriesEl.disabled = false;
       countriesEl.setAttribute('aria-expanded', 'false');
@@ -338,7 +345,7 @@ export function renderStats(metrics) {
   if (roasterDropdown && roasterList) {
     if (roasterCountries.length) {
       roasterList.innerHTML = renderCountryList(roasterCountries);
-      setDropdownWidth(roasterDropdown);
+      setDropdownWidth(roasterDropdown, container);
       roasterDropdown.hidden = true;
       if ('disabled' in roasterCountriesEl) roasterCountriesEl.disabled = false;
       roasterCountriesEl.setAttribute('aria-expanded', 'false');
@@ -358,7 +365,7 @@ export function renderStats(metrics) {
   if (consumedDropdown && consumedList) {
     if (consumedCountries.length) {
       consumedList.innerHTML = renderCountryList(consumedCountries);
-      setDropdownWidth(consumedDropdown);
+      setDropdownWidth(consumedDropdown, container);
       consumedDropdown.hidden = true;
       if ('disabled' in consumedCountriesEl) consumedCountriesEl.disabled = false;
       consumedCountriesEl.setAttribute('aria-expanded', 'false');


### PR DESCRIPTION
### Motivation
- Make the country/roaster/consumed lists open visually as a continuation of the stats panel rather than a floating box with its own scrollbar.  
- Ensure the dropdown width fits the longest country name and avoid line-wrapping/truncation by computing a measured width.  
- If necessary, allow the stats form to expand so the opened list and the form align visually as a single element.

### Description
- Updated `.map-stat-dropdown` styles in `css/style.css` to remove internal scrolling, remove the top border and connect the dropdown to the stats panel by adjusting `top`, `overflow`, `max-height` and `border-radius`.  
- Changed `setDropdownWidth` in `js/ui-controls.js` to accept an `anchorContainer` and ensure the dropdown width is at least the stats container width while using the measured longest country name.  
- Modified `positionDropdownBelowButton` to accept a `root` element and align the opened dropdown to the left edge/bottom of the overall stats container instead of the single metric button, and adjusted the vertical gap to sit flush.  
- Wired the new sizing/positioning behavior into all three dropdowns (countries, roaster countries, consumed countries) by passing the `container` and `root` where appropriate.

### Testing
- Ran the prebuilt test suite with `npm run test:prebuilt`, which did not complete here because Playwright browser binaries are not present in the environment (`Executable doesn't exist ... headless_shell`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8dc6904808331b7b3f85326a18ad0)