### PR TITLE
Tighten popup field width in multi-card map popups

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1039,6 +1039,11 @@ body[data-theme="dark"] .map-error{
   row-gap:2px;
 }
 
+.popup-card--compact-fields .popup-fields{
+  max-width:252px;
+  margin-inline:auto;
+}
+
 .popup-field{
   margin:2px 0;
   display:flex;

--- a/js/map-init.js
+++ b/js/map-init.js
@@ -203,7 +203,7 @@ function flagFromRow(flagEmojiCell, iso2Cell, flagMode) {
   return emoji || '🏳️';
 }
 
-function popupHTML(p, flagMode) {
+function popupHTML(p, flagMode, { compactFields = false } = {}) {
   const flag = flagFromRow(p.flagEmoji, p.countryIso2, flagMode);
   const country = p.originCountry ? ((flag ? `${flag} ` : '') + escapeHtml(p.originCountry)) : '';
   const region = escapeHtml(p.originRegion || '');
@@ -242,7 +242,7 @@ function popupHTML(p, flagMode) {
     : '';
 
   return `
-    <div class="popup-card">
+    <div class="popup-card${compactFields ? ' popup-card--compact-fields' : ''}">
       ${badge}
       ${photo}
       <div class="popup-body">
@@ -801,7 +801,7 @@ export function createMapController({ mapboxgl, accessToken, theme, flagMode, en
              <button type="button" data-next style="padding:8px 12px;border:1px solid var(--glass-br);background:var(--glass);border-radius:10px;cursor:pointer;touch-action:manipulation">▶</button>
            </div>`
         : '';
-      popup.setHTML(popupHTML(properties, state.flagMode) + nav);
+      popup.setHTML(popupHTML(properties, state.flagMode, { compactFields: features.length > 1 }) + nav);
 
       setTimeout(() => {
         const el = popup.getElement();


### PR DESCRIPTION
### Motivation
- Сделать поля в попапах уже и визуально центрированными, когда в них показываются кнопки переключения карточек (◀/▶), чтобы контент не растягивался рядом с навигацией.

### Description
- Добавлен опциональный параметр `compactFields` в `popupHTML` и модификатор класса `popup-card--compact-fields` в `js/map-init.js`.
- Включение `compactFields` при рендере мульти-карточек (`features.length > 1`), где отображаются prev/next кнопки, в `showMultiPopup`.
- В `css/style.css` добавлено правило `.popup-card--compact-fields .popup-fields` с `max-width:252px` и `margin-inline:auto` для сужения и центрирования блока полей.
- Изменены файлы: `js/map-init.js`, `css/style.css`.

### Testing
- Запущена команда `node --check js/map-init.js` — прошла успешно.
- Запущена команда `node --check js/app.js` — прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8ddf9c6e48331aba0a238fe09e507)