### PR TITLE
Make multi-feature popups use compact field layout and tweak nav spacing

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1039,6 +1039,11 @@ body[data-theme="dark"] .map-error{
   row-gap:2px;
 }
 
+.popup-card--compact-fields .popup-fields{
+  max-width:252px;
+  margin-inline:auto;
+}
+
 .popup-field{
   margin:2px 0;
   display:flex;

--- a/js/map-init.js
+++ b/js/map-init.js
@@ -203,7 +203,7 @@ function flagFromRow(flagEmojiCell, iso2Cell, flagMode) {
   return emoji || '🏳️';
 }
 
-function popupHTML(p, flagMode) {
+function popupHTML(p, flagMode, { compactFields = false } = {}) {
   const flag = flagFromRow(p.flagEmoji, p.countryIso2, flagMode);
   const country = p.originCountry ? ((flag ? `${flag} ` : '') + escapeHtml(p.originCountry)) : '';
   const region = escapeHtml(p.originRegion || '');
@@ -242,7 +242,7 @@ function popupHTML(p, flagMode) {
     : '';
 
   return `
-    <div class="popup-card">
+    <div class="popup-card${compactFields ? ' popup-card--compact-fields' : ''}">
       ${badge}
       ${photo}
       <div class="popup-body">
@@ -795,13 +795,13 @@ export function createMapController({ mapboxgl, accessToken, theme, flagMode, en
       const feature = features[index];
       const properties = feature.properties;
       const nav = (features.length > 1)
-        ? `<div class="popup-nav" style="display:flex;align-items:center;justify-content:space-between;margin:8px 14px 14px;gap:8px">
+        ? `<div class="popup-nav" style="display:flex;align-items:center;justify-content:space-between;margin:8px 14px 6px;gap:8px">
              <button type="button" data-prev style="padding:8px 12px;border:1px solid var(--glass-br);background:var(--glass);border-radius:10px;cursor:pointer;touch-action:manipulation">◀</button>
              <div class="idx" style="font:12px/1.1 system-ui;color:var(--muted)">${index + 1} из ${features.length}</div>
              <button type="button" data-next style="padding:8px 12px;border:1px solid var(--glass-br);background:var(--glass);border-radius:10px;cursor:pointer;touch-action:manipulation">▶</button>
            </div>`
         : '';
-      popup.setHTML(popupHTML(properties, state.flagMode) + nav);
+      popup.setHTML(popupHTML(properties, state.flagMode, { compactFields: features.length > 1 }) + nav);
 
       setTimeout(() => {
         const el = popup.getElement();


### PR DESCRIPTION
### Motivation
- Prevent overly wide popups when multiple features are shown in a single popup by constraining field column width and centering content.
- Improve visual spacing of the popup navigation controls to reduce excessive bottom margin.

### Description
- Added CSS rule `.popup-card--compact-fields .popup-fields` to limit `max-width:252px` and center it with `margin-inline:auto`.
- Extended `popupHTML` signature to accept an options object `({ compactFields = false } = {})` and apply the `popup-card--compact-fields` class when enabled.
- Updated multi-feature popup rendering to pass `compactFields: features.length > 1` to `popupHTML` so popups with multiple items use the compact layout.
- Reduced the popup navigation container bottom margin from `14px` to `6px` for tighter spacing.

### Testing
- Ran `npm run build` and the build completed successfully.
- Ran `npm test` and unit tests passed (no regressions detected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8ddf9c6e48331aba0a238fe09e507)