### PR TITLE
Avoid stretching stat tile when sizing country dropdown

### DIFF
--- a/js/ui-controls.js
+++ b/js/ui-controls.js
@@ -136,9 +136,6 @@ const setDropdownWidth = (dropdown, anchorContainer) => {
     const anchorWidth = anchorContainer?.offsetWidth || 0;
     const targetWidth = Math.max(width, anchorWidth);
     dropdown.style.width = `${targetWidth}px`;
-    if (anchorContainer && targetWidth > anchorWidth) {
-      anchorContainer.style.width = `${targetWidth}px`;
-    }
   }
 };
 


### PR DESCRIPTION
### Motivation
- Prevent the KPI/stat tile from being widened when sizing the country dropdown so the dropdown fits each country name without leaving excessive empty space.

### Description
- In `js/ui-controls.js` removed the code in `setDropdownWidth` that propagated the computed `targetWidth` to `anchorContainer.style.width`, leaving the dropdown width computed by `calculateDropdownWidth` and applied only to the dropdown.

### Testing
- Ran `node --check js/ui-controls.js` which passed, and ran `npm run -s check:dataset` which failed in this environment due to missing `data/dataset.json` (environment issue, not related to the change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e0e348f0833187b2d8d37817f5ca)