### PR TITLE
Reduce map stats dropdown width

### DIFF
--- a/js/ui-controls.js
+++ b/js/ui-controls.js
@@ -133,8 +133,8 @@ const calculateDropdownWidth = (dropdown) => {
 const setDropdownWidth = (dropdown, anchorContainer) => {
   const width = calculateDropdownWidth(dropdown);
   if (Number.isFinite(width) && width > 0) {
-    const anchorWidth = anchorContainer?.offsetWidth || 0;
-    const targetWidth = Math.max(width, anchorWidth);
+    const MIN_DROPDOWN_WIDTH = 160;
+    const targetWidth = Math.max(width, MIN_DROPDOWN_WIDTH);
     dropdown.style.width = `${targetWidth}px`;
   }
 };


### PR DESCRIPTION
### Motivation
- Prevent map stats dropdowns from stretching to the full stats container width and make them sized to content with a compact minimum.

### Description
- Change in `js/ui-controls.js`: `setDropdownWidth` now uses the measured `calculateDropdownWidth(dropdown)` and applies a `MIN_DROPDOWN_WIDTH` of `160` instead of expanding to the `anchorContainer` width.

### Testing
- Ran `node --check js/ui-controls.js` which completed successfully.
- Ran `npm run check:dataset` which failed in this environment because `data/dataset.json` is missing and is not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f2bcf74c8331848fadb2d57c4221)