### PR TITLE
Make map stat dropdown width dynamic and clamp to viewport

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -325,7 +325,7 @@ body[data-theme="dark"] .map-loading{
   position:absolute;
   top:calc(100% - 1px);
   left:0;
-  min-width:200px;
+  min-width:0;
   width:max-content;
   max-width:min(280px,calc(100vw - 32px));
   max-height:none;

--- a/js/ui-controls.js
+++ b/js/ui-controls.js
@@ -130,12 +130,10 @@ const calculateDropdownWidth = (dropdown) => {
   return Math.ceil(longestName + gap + flagWidth + padding + border);
 };
 
-const setDropdownWidth = (dropdown, anchorContainer) => {
+const setDropdownWidth = (dropdown) => {
   const width = calculateDropdownWidth(dropdown);
   if (Number.isFinite(width) && width > 0) {
-    const anchorWidth = anchorContainer?.offsetWidth || 0;
-    const targetWidth = Math.max(width, anchorWidth);
-    dropdown.style.width = `${targetWidth}px`;
+    dropdown.style.width = `${width}px`;
   }
 };
 
@@ -152,9 +150,14 @@ const positionDropdownBelowButton = (dropdown, button, root) => {
   const parentRect = parent.getBoundingClientRect();
   const viewportWidth = globalScope?.document?.documentElement?.clientWidth || globalScope?.innerWidth || 0;
   const dropdownStyle = globalScope.getComputedStyle ? getComputedStyle(dropdown) : null;
-  const measuredWidth = dropdown.offsetWidth
+  let measuredWidth = dropdown.offsetWidth
     || parseSize(dropdownStyle?.width)
     || parseSize(dropdown.style.width);
+  const maxAllowedWidth = viewportWidth ? Math.max(viewportWidth - (VIEWPORT_MARGIN * 2), 0) : 0;
+  if (maxAllowedWidth && measuredWidth > maxAllowedWidth) {
+    measuredWidth = maxAllowedWidth;
+    dropdown.style.width = `${maxAllowedWidth}px`;
+  }
 
   const initialLeft = (statsRect ? statsRect.left : buttonRect.left) - parentRect.left;
   const top = ((statsRect ? statsRect.bottom : (buttonRect.top + button.offsetHeight)) - parentRect.top) + GAP;


### PR DESCRIPTION
### Motivation
- Prevent the stats dropdown from forcing a wide minimum and from overflowing the viewport by sizing it to content and clamping to available space.

### Description
- Change CSS `min-width` for `.map-stat-dropdown` from `200px` to `0` to allow content-based sizing.
- Simplify `setDropdownWidth` to apply the calculated content width directly instead of expanding to the anchor container width. 
- In `positionDropdownBelowButton` read the measured width, compute a `maxAllowedWidth` based on the viewport and `VIEWPORT_MARGIN`, clamp the dropdown width to that maximum, and update `dropdown.style.width` when necessary.

### Testing
- Ran `npm run lint` and linting passed.
- Ran `npm test` and unit tests completed without failures.
- Performed a production build with `npm run build` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f2bcf74c8331848fadb2d57c4221)